### PR TITLE
Make husky hooks silent

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -9,8 +9,8 @@ console.log('\033[36m%s\033[0m', 'husky')
 console.log('  setting up hooks in .git/hooks/')
 
 if (fs.existsSync(dir)) {
-  husky.create(dir, 'pre-commit', 'npm run precommit')
-  husky.create(dir, 'pre-push', 'npm run prepush')
+  husky.create(dir, 'pre-commit', 'npm run precommit --silent')
+  husky.create(dir, 'pre-push', 'npm run prepush --silent')
   console.log('  done\n')
 } else {
   console.log('  can\'t find .git/hooks/\n')


### PR DESCRIPTION
I get bunch of npm output, if precommit/prepush hook is failing:

```
npm ERR! bar.export@0.0.0 precommit: `gulp lint`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the bar.export@0.0.0 precommit script.
npm ERR! This is most likely a problem with the bar.export package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp lint
npm ERR! You can get their info via:
npm ERR!     npm owner ls bar.export
npm ERR! There is likely additional logging output above.
npm ERR! System Darwin 13.2.0
npm ERR! command "node" "/usr/local/bin/npm" "run" "precommit"
npm ERR! cwd /Users/floatdrop/bar.export
npm ERR! node -v v0.10.28
npm ERR! npm -v 1.4.16
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/floatdrop/bar.export/npm-debug.log
npm ERR! not ok code 0
```

This is kind of distracting - you should scroll up to see actual errors. So may be append `--silent` to npm run command?
