### PR TITLE
Force exit with code 1 on hook fail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ module.exports = {
       '  echo "husky"',
       '  echo "  To bypass ' + name + ' hook add -n or --no-verify"',
       '  echo',
+      '  exit 1',
       'fi'
     ].join('\n')
 


### PR DESCRIPTION
I think this is expected behaviour - to prevent commit command to execute if precommit task is failing.
