### PR TITLE
handle projects that do not have package.json in root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,15 @@ module.exports = {
       data += 'PATH="' + process.env.PATH + '"\n'
     }
 
+    // Get the path of the projects .git
+    var projectPath = dir.replace('.git/hooks', '')
+    
+    // Need to find relative path from projects .git -> package.json
+    var relativePath = process.env.PWD.replace(projectPath,'').split('/node_modules')[0]
+
     data +=
-        'npm run --json | grep -q \'"' + cmd + '":\'\n' // fix for issue #16
+        'cd ./' + relativePath + '\n'
+      + 'npm run --json | grep -q \'"' + cmd + '":\'\n' // fix for issue #16
       + 'if [ $? -ne 0 ]; then\n'
       + '  exit 0\n' // package.scripts[name] can't be found exit
       + 'fi\n'


### PR DESCRIPTION
Compares the directory containing .git and the directory of containing husky to find the directory of the package.json file.  The relative path derived from this comparison is then added to the scripts in the .git/hooks files.  

This allows npm run --json to execute properly, instead of resulting in the following error:
```
npm ERR! npm run-script [<pkg>] <command>
npm ERR! not ok code 0
```