### PR TITLE
pass $1 to script if hook is commitmsg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = {
       + '[ -f package.json ] && cat package.json | grep -q \'"' + cmd + '"\\s*:\'\n'
         // package.json or script can't be found exit
       + '[ $? -ne 0 ] && exit 0\n'
-      + 'npm run ' + cmd + ' --silent\n'
+      + 'npm run ' + cmd + ( cmd === 'commitmsg' ? ' $1' : '') + ' --silent\n'
       + 'if [ $? -ne 0 ]; then\n'
       + '  echo\n'
       + '  echo "husky - ' + name + ' hook failed (add --no-verify to bypass)"\n'


### PR DESCRIPTION
There is definitely a better way to do this, passing any args along to the script to consider or ignore as necessary, but this should let users actually act on the commit message when using this hook.