### PR TITLE
run npm scripts with arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ module.exports = {
       '[ -f package.json ] && cat package.json | grep -q \'"' + cmd + '"\\s*:\'',
       // package.json or script can't be found exit
       '[ $? -ne 0 ] && exit 0',
-      'npm run ' + cmd + ' --silent',
+      'npm run ' + cmd + ' --silent $@',
       'if [ $? -ne 0 ]; then',
       '  echo',
       '  echo "husky - ' + name + ' hook failed (add --no-verify to bypass)"',


### PR DESCRIPTION
because for example in `prepare-commit-msg` hook `$1` means current message file, so we need to be able to change it.