### PR TITLE
Replace `npm rm` with `npm uninstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git commit -m "Keep calm and commit"
 
 Existing hooks aren't replaced and adding `--no-verify` to your git commands lets you bypass hooks. You can also use [any](https://github.com/typicode/husky/blob/master/hooks.json) Git hook.
 
-To uninstall husky, simply run `npm rm husky --save-dev`
+To uninstall husky, simply run `npm uninstall husky --save-dev`
 
 ## License
 


### PR DESCRIPTION
I find using `npm uninstall` clearer to any of its aliases (`remove`, `rm`, `r`, `un`, `unlink`) mainly because of its counterpart being `npm install`.

Hopefully you'll agree.

Thanks!