### PR TITLE
Fix bin scripts to use proper nodejs binary

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Run when package is installed
 var fs    = require('fs')
 var husky = require('../src/')

--- a/bin/uninstall.js
+++ b/bin/uninstall.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Run when package is uninstalled
 var husky = require('../src/')
 var hooks = require('../src/hooks.json')

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node test",
-    "install": "node ./bin/install.js",
-    "uninstall": "node ./bin/uninstall.js"
+    "install": "bin/install.js",
+    "uninstall": "bin/uninstall.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There is no guaranty that `node` binary is present in the user's path during module installation. It's a common practise to use `/usr/bin/env node`, so call `/opt/nodejs/5/bin/node /opt/nodejs/5/bin/npm install` could work.

Unfortunately, I don't have any Windows experience and no possibility to test that. So it'd be awesome if anybody could verify everything still works on Windows.