### PR TITLE
Readd setting PATH in hooks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,12 @@ module.exports = {
       '#!/bin/sh',
       '# husky'
     ]
-
+    
+    // Needed on OS X / Linux when nvm is used and committing from GUI-Tools
+    // like Sublime Text, SourceTree, ...
+    if (process.platform !== 'win32') {
+      arr.push('PATH="' + process.env.PATH + '"')
+    }
     // Assuming that this file is in node_modules/husky/src
     var packageDir = path.join(__dirname, '..', '..', '..')
 


### PR DESCRIPTION
commit 8efa2bca4ef31a099e822898149ee96e5a94c780 removed these lines, but they
are important for GUI-Tools on Mac OS X. If they are not present these tools can't locate
npm/node/nvm, which then leads to a silent fail.

In my case SourceTree was not able to run the hooks, because by default it uses the default PATH for GUI tools which can't be changed on OSX.

Was there a reason why this was removed?