### PR TITLE
Export path environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ module.exports = {
 
     // Hook script
     arr = arr.concat([
+      'export PATH=' + process.env.PATH + ':$PATH',
       'cd ' + normalizedPath,
 
       // Fix for issue #16 #24


### PR DESCRIPTION
When using git with a GUI app (like Tower) instead of the CLI, it [doesn't know about the environment variables](https://www.git-tower.com/help/mac/faq-and-tips/faq/hook-scripts) you may have set up and just ignores any git hooks.

Exporting `PATH` inside the hook script itself allows the GUI to run the hook as expected.