### PR TITLE
Run NPM command silently

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ module.exports = {
 
       // Run script
       'export GIT_PARAMS="$*"',
-      'npm run ' + cmd,
+      'npm run ' + cmd + ' --silent',
       'if [ $? -ne 0 ]; then',
       '  echo',
       '  echo "husky - ' + name + ' hook failed (add --no-verify to bypass)"',


### PR DESCRIPTION
This will suppress the `NPM ERR!` lines if the script exits with a non-zero exit code. (Those lines may be useful in an NPM context, but this is in a Git context, where the `NPM ERR!` lines are just confusing and noisy.)
