### PR TITLE
Fixing sh syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,8 @@ module.exports = {
       'command -v npm >/dev/null 2>&1 || { echo >&2 "' + npmNotFound + '"; exit 0; }',
 
       // Run script
-      'export GIT_PARAMS=$*',
+      'GIT_PARAMS="$*"',
+      'export GIT_PARAMS',
       'npm run ' + cmd,
       'if [ $? -ne 0 ]; then',
       '  echo',
@@ -99,6 +100,7 @@ module.exports = {
       '  echo',
       '  exit 1',
       'fi',
+      'exit 0',
       ''
     ])
 


### PR DESCRIPTION
The old version broke on ubuntu 16 to use syntax 'bash' in 'sh'