### PR TITLE
Fix parameter handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ module.exports = {
       'command -v npm >/dev/null 2>&1 || { echo >&2 "' + npmNotFound + '"; exit 0; }',
 
       // Run script
-      'export GIT_PARAMS=$*',
+      'export GIT_PARAMS="$*"',
       'npm run ' + cmd,
       'if [ $? -ne 0 ]; then',
       '  echo',


### PR DESCRIPTION
The following commit broke our setup: https://github.com/typicode/husky/commit/4d43602938097dd727fbcd4a3196bd0ebb6e9c11

This is a simple fix to prevent errors when `$*` expands to more than one value.

Cheers!