### PR TITLE
Support cygpath for cygwin-based git executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "is-ci": "^1.0.9",
-    "normalize-path": "^1.0.0"
+    "normalize-path": "^1.0.0",
+    "which": "^1.2.11"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var exec = require('child_process').exec
 var normalize = require('normalize-path')
+var which = require('which')
 
 module.exports = {
   isHusky: function (filename) {
@@ -14,7 +15,18 @@ module.exports = {
       if (error) {
         callback(stderr, null)
       } else {
-        callback(null, stdout.trim() + '/hooks')
+        var hooksPath = stdout.trim() + '/hooks'
+        if (process.platform === 'win32' && which.sync('cygpath')) {
+          exec('cygpath -w ' + hooksPath, function (cygError, cygStdout, cygStdErr) {
+            if (cygError) {
+              callback(cygStdEr, null)
+            } else {
+              callback(null, cygStdout.trim())
+            }
+          })
+        } else {
+          callback(null, hooksPath)
+        }
       }
     })
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,13 +3,14 @@ var fs = require('fs')
 var path = require('path')
 var rmrf = require('rimraf')
 var husky = require('../src/')
+var normalize = require('normalize-path')
 
 // Some very basic tests...
 
 // should return git hooks path
 husky.hooksDir(function (err, dir) {
   assert.equal(err, null)
-  assert.equal(dir, '.git/hooks')
+  assert.equal(normalize(dir), '.git/hooks')
 })
 
 // Reset tmp dir


### PR DESCRIPTION
This PR updates behavior of getting git path for edge-case windows users, like using git executable from `msys2` or similar (i.e, `cygwin`).

Since those git executable returns path as *nix style in windows system, it'll end up husky hook installation fails by

> husky
> setting up hooks in .git/hooks
> fs.js:922
>   return binding.mkdir(pathModule._makeLong(path),
>                  ^
> 
> Error: ENOENT: no such file or directory, mkdir 'Z:\z\github\g.git\hooks'
>     at Error (native)
>     at Object.fs.mkdirSync (fs.js:922:18)
>     at Object.module.exports.create (Z:\github\g\node_modules\husky\src\index.js:123:33)
>     at Z:\github\g\node_modules\husky\bin\install.js:22:13
>     at Array.forEach (native)
>     at Z:\github\g\node_modules\husky\bin\install.js:20:11
>     at Z:\github\g\node_modules\husky\src\index.js:17:9
>     at ChildProcess.exithandler (child_process.js:193:7)
>     at emitTwo (events.js:106:13)
>     at ChildProcess.emit (events.js:191:7)

try to create hook under `Z:\z\github\g\.git\hooks`, instead of correct windows path `Z:\github\g\.git\hooks`

In changes, it borrows `cygpath` included in `msys2` and `cygwin` and let it correct path to windows style paths.
