### PR TITLE
Allow custom husky config

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1,8 +1,11 @@
 // Run when package is installed
-var fs    = require('fs')
-var isCI  = require('is-ci')
-var husky = require('../src/')
-var hooks = require('../src/hooks.json')
+var fs       = require('fs')
+var isCI     = require('is-ci')
+var findRoot = require('find-root')
+var husky    = require('../src/')
+var hooks    = require('../src/hooks.json')
+
+var package  = findRoot('package.json')
 
 if (isCI) {
   console.log('\033[4;36m%s\033[0m', 'husky')
@@ -17,9 +20,13 @@ husky.hooksDir(function(err, dir) {
   if (err) {
     console.error('  ' + err)
   } else {
+    var config = package && package.config && package.config.husky
+      ? package.config.husky
+      : {};
+
     hooks.forEach(function (hook) {
       script = hook.replace(/-/g, '')
-      husky.create(dir, hook, script)
+      husky.create(dir, hook, script, config)
     })
     console.log('done\n')
   }

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,11 +1,9 @@
 // Run when package is installed
 var fs       = require('fs')
 var isCI     = require('is-ci')
-var findRoot = require('find-root')
+var path     = require('path')
 var husky    = require('../src/')
 var hooks    = require('../src/hooks.json')
-
-var package  = findRoot('package.json')
 
 if (isCI) {
   console.log('\033[4;36m%s\033[0m', 'husky')
@@ -16,12 +14,34 @@ if (isCI) {
 console.log('\033[4;36m%s\033[0m', 'husky')
 console.log('setting up hooks in .git/hooks')
 
+function getPackageJson() {
+  var filePath = process.cwd().split(path.sep);
+
+  while(filePath.length > 1) {
+    var search = path.join(filePath.join(path.sep), 'package.json');
+
+    try {
+      if (fs.statSync(search)) {
+        var json = require(search)
+        if (json.config && json.config.husky) {
+          return json;
+        }
+      }
+    } catch (e) {}
+
+    filePath.pop();
+  }
+
+  return null;
+}
+
 husky.hooksDir(function(err, dir) {
   if (err) {
     console.error('  ' + err)
   } else {
-    var config = package && package.config && package.config.husky
-      ? package.config.husky
+    var json = getPackageJson();
+    var config = json !== null && json.config && json.config.husky
+      ? json.config.husky
       : {};
 
     hooks.forEach(function (hook) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "rimraf": "^2.2.8"
   },
   "dependencies": {
-    "find-root": "^1.0.0",
     "is-ci": "^1.0.9",
     "normalize-path": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "rimraf": "^2.2.8"
   },
   "dependencies": {
+    "find-root": "^1.0.0",
     "is-ci": "^1.0.9",
     "normalize-path": "^1.0.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = {
     fs.chmodSync(filename, 0755)
   },
 
-  create: function (dir, name, cmd) {
+  create: function (dir, name, cmd, config) {
     var filename = dir + '/' + name
     var arr = [
       '#!/bin/sh',
@@ -103,13 +103,17 @@ module.exports = {
     // Can't find npm message
     var npmNotFound = 'husky - can\'t find npm in PATH. Skipping ' + cmd + ' script in package.json'
 
+    var silent = !!config.silent
+      ? '--silent'
+      : '';
+
     arr = arr.concat([
       // Test if npm is in PATH
       'command -v npm >/dev/null 2>&1 || { echo >&2 "' + npmNotFound + '"; exit 0; }',
 
       // Run script
       'export GIT_PARAMS="$*"',
-      'npm run ' + cmd,
+      'npm run ' + cmd + ' ' + silent,
       'if [ $? -ne 0 ]; then',
       '  echo',
       '  echo "husky - ' + name + ' hook failed (add --no-verify to bypass)"',

--- a/test/index.js
+++ b/test/index.js
@@ -20,12 +20,12 @@ var dir = path.join(__dirname, '../tmp/hooks')
 
 // husky should be able to create hooks directory and hook script
 assert.doesNotThrow(function () {
-  husky.create(dir, 'pre-commit', 'foo')
+  husky.create(dir, 'pre-commit', 'foo', {})
 })
 
 // husky should be able to update hook script
 assert.doesNotThrow(function () {
-  husky.create(dir, 'pre-commit', 'bar')
+  husky.create(dir, 'pre-commit', 'bar', {})
 })
 
 assert(fs.readFileSync(dir + '/pre-commit', 'utf-8').indexOf('bar') !== -1)
@@ -37,7 +37,7 @@ assert(!fs.existsSync(dir + '/pre-commit'))
 // husky shouldn't be able to modify a user hook
 fs.writeFileSync(dir + '/user-pre-commit', '')
 
-husky.create(dir, 'user-pre-commit', 'foo')
+husky.create(dir, 'user-pre-commit', 'foo', {})
 husky.remove(dir, 'user-pre-commit')
 
 assert.equal(fs.readFileSync(dir + '/user-pre-commit', 'utf-8'), '')


### PR DESCRIPTION
This PR allows the user to pass custom configuration options to husky via the (little known) [config-property](https://docs.npmjs.com/files/package.json#config) inside `package.json`.

In a nutshell this is a different approach to https://github.com/typicode/husky/pull/54, with the addition that the current defaults remain the same and we can satisfy both worlds.

It works by getting traversing the tree upwards until it reaches the topmost `package.json` and using the `config.husky` property if any is present. Otherwise it simply falls back to an empty config.

``` json
{
  "name": "mypackage",
  "scripts": {
    "precommit": "whatever..."
  },
  "config": {
    "husky": {
      "silent": "true"
    }
  }
}
```

Fixes https://github.com/typicode/husky/issues/64.
