### PR TITLE
HyperTerm is now called Hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Husky can prevent bad commit, push and more :dog: _woof!_
 
-_Used by [jQuery](https://github.com/jquery/jquery), [HyperTerm](https://github.com/zeit/hyperterm), [Paper.js](https://github.com/paperjs/paper.js), [Kibana](https://github.com/elastic/kibana), [JSON Server](https://github.com/typicode/json-server), [Hotel](https://github.com/typicode/hotel), ... and many other awesome projects._
+_Used by [jQuery](https://github.com/jquery/jquery), [Hyper](https://github.com/zeit/hyper), [Paper.js](https://github.com/paperjs/paper.js), [Kibana](https://github.com/elastic/kibana), [JSON Server](https://github.com/typicode/json-server), [Hotel](https://github.com/typicode/hotel), ... and many other awesome projects._
 
 ## Usage
 


### PR DESCRIPTION
We had to rename the project. This is the new name and link.