### PR TITLE
Fixes issue with submodules with a package.json not in .git's dir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,19 +34,16 @@ module.exports = {
     // Assuming that this file is in node_modules/husky/src
     var packageDir = path.join(__dirname, '..', '..', '..')
 
-    // dir being .git/hooks
-    var projectDir = path.join(dir, '..', '..')
-
     // In order to support projects with package.json in a different directory
-    // than .git, find relative path from project directory to package.json
-    var relativePath = path.join('.', path.relative(projectDir, packageDir))
+    // than .git, find relative path from hook directory to package.json
+    var relativePath = path.join('.', path.relative(dir, packageDir))
 
     // On Windows normalize path (i.e. convert \ to /)
-    var normalizedPath = normalize(relativePath)
+    var normalizedPath = normalize('/'+relativePath)
 
     // Hook script
     arr = arr.concat([
-      'cd ' + normalizedPath,
+      'cd $(dirname "$0")' + normalizedPath,
 
       // Fix for issue #16 #24
       // Test if script is defined in package.json


### PR DESCRIPTION
This is a fix for issue #20 

In a submodule (with git version 1.7.8+) "dir" is located inside parent's .git directory.

`var projectDir = path.join(dir, '..', '..')` is not the appropriate folder in this case.

How I implemented it is that I calculate the path from the hook directory to the `package.json`'s directory which is accurate all the time.

The hook script moves from its folder to the relative path provided.

Another approach would be to run both `git rev-parse --show-toplevel` and `git rev-parse --git-dir` then calculate a path satisfying all cases.