### PR TITLE
Support for SmartGit on OSX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,8 @@ function getHookScript (hookName, relativePath, cmd) {
     ''
   ])
 
+  echo "process.platform: " + process.platform;
+  
   // On OS X and Linux, try to use nvm if it's installed
   if (process.platform !== 'win32') {
     // ~ is unavaible, so $HOME is used

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ function getHookScript (hookName, relativePath, cmd) {
     // ~ is unavaible, so $HOME is used
     var home = process.env.HOME
 
-    if (process.platform === 'darwin') {
+    if (process.platform === 'darwin' || process.platform === 'linux') {
       // Add
       // Brew standard installation path /use/local/bin
       // Node standard installation path /usr/local

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,6 @@ function getHookScript (hookName, relativePath, cmd) {
     '[ $? -ne 0 ] && exit 0',
     ''
   ])
-
-  echo "process.platform: " + process.platform;
   
   // On OS X and Linux, try to use nvm if it's installed
   if (process.platform !== 'win32') {
@@ -114,7 +112,7 @@ function getHookScript (hookName, relativePath, cmd) {
   }
 
   // Can't find npm message
-  var npmNotFound = 'husky - can\'t find npm in PATH. Skipping ' + cmd + ' script in package.json'
+  var npmNotFound = 'husky - can\'t find npm in PATH. Skipping ' + cmd + ' script in package.json . process.platform: ' + process.platform
 
   arr = arr.concat([
     // Test if npm is in PATH


### PR DESCRIPTION
When running SmartGit v6 on OSX v10.11.2 process.platform is set to 'linux'.