### PR TITLE
nvm loading fixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ function getHookScript (hookName, relativePath, cmd) {
 
     'load_nvm () {',
     '  export $1=$2',
-    '  [ -s "$1/nvm.sh" ] && . $1/nvm.sh',
-    '  exists nvm && [ -f .nvmrc ] && nvm use',
+    '  [ -s "$2/nvm.sh" ] && . $2/nvm.sh',
+    '  command_exists nvm && [ -f .nvmrc ] && nvm use',
     '}',
     '',
 


### PR DESCRIPTION
This fixes nvm loading.
it tried to read NVM_DIR/nvm.sh, it correctly searches for the nvm.sh now.
It also tried exists which is not defined. I guess command_exists was intended.