### PR TITLE
Fix loading `nvm`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ function getHookScript (hookName, relativePath, cmd) {
 
     'load_nvm () {',
     '  export $1=$2',
-    '  [ -s "$1/nvm.sh" ] && . $1/nvm.sh',
-    '  exists nvm && [ -f .nvmrc ] && nvm use',
+    '  [ -s "$2/nvm.sh" ] && . $2/nvm.sh',
+    '  command_exists nvm && [ -f .nvmrc ] && nvm use',
     '}',
     '',
 


### PR DESCRIPTION
`nvm` couldn't be loaded when a specific version of `npm` was in the path even when a `.nvmrc` was added to the project root. This change allows to place a file `.nvmrc` into the project root which will be picked up by husky.

Additionally two apparent bugs are fixed:
* `exists` doesn't seem to be a command neither on macOS nor on Linux, might be a typo
* the test for the file `nvm.sh` is wrong