### PR TITLE
Fix package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "husky",
   "version": "0.13.1",
   "description": "Prevents bad commit or push (git hooks, pre-commit/precommit, pre-push/prepush, post-merge/postmerge and all that stuff...)",
-  "main": "index.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "mocha && standard",
     "precommit": "npm test",


### PR DESCRIPTION
Before this changes, the entry point was erroneous causing errors when requiring this package:

```js
const husky = require("husky")
```
```
Error: Cannot find module 'husky'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/fc/husky-test/scripts/install.js:3:15)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```