### PR TITLE
Correct work with worktrees

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function findHooksDir (dirname) {
         .split(':')[1]
         .trim()
 
-      return path.join(dir, gitDir, 'hooks')
+      return path.resolve(dir, gitDir, 'hooks')
     }
 
     return path.join(gitDir, 'hooks')

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,22 @@ describe('husky', function () {
     expect(exists('hooks/pre-push')).toBeFalsy()
   })
 
+  it('should support git worktrees', function () {
+    mock({
+      '/.git/worktrees/B': {},
+      '/A/B/.git': 'git: /.git/worktrees/B',
+      '/A/B/node_modules/husky': {}
+    })
+
+    husky.installFrom('/A/B/node_modules/husky')
+    var hook = readHook('worktrees/B/hooks/pre-commit')
+
+    expect(hook).toInclude('cd .')
+
+    husky.uninstallFrom('/A/B/node_modules/husky')
+    expect(exists('hooks/pre-commit')).toBeFalsy()
+  })
+
   it('should not modify user hooks', function () {
     mock({
       '/.git/hooks': {},


### PR DESCRIPTION
Worktree's `.git` file contains absolute path to repository.
`path.join` incorrectly concatenates `/path/to/worktree`
with `/path/to/real/.git/worktrees/worktree` to
`/path/to/worktree/path/to/real/.git/worktrees/worktree`
instead of simple `/path/to/real/...`

Using `path.resolve` instead of `path.join` resolves this problem
while relative paths of submodules still works correctly.