### PR TITLE
Add .npmignore (closes #121)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test/
+.travis.yml
+


### PR DESCRIPTION
Removes files in test/ and the .travis.yml from the npm registry to make the package a bit smaller.