### PR TITLE
Fix. Escape spaces in window file path

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -45,7 +45,7 @@ describe('husky', () => {
     const hook = readFile(dir, '.git/hooks/pre-commit')
 
     expect(hook).toMatch('#husky')
-    expect(hook).toMatch('cd .')
+    expect(hook).toMatch('cd "."')
     expect(hook).toMatch('npm run -s precommit')
     expect(hook).toMatch('--no-verify')
 
@@ -63,7 +63,7 @@ describe('husky', () => {
     install(dir, 'A/B/node_modules/husky')
     const hook = readFile(dir, '.git/hooks/pre-commit')
 
-    expect(hook).toMatch('cd A/B')
+    expect(hook).toMatch('cd "A/B"')
 
     uninstall(dir, 'A/B/node_modules/husky')
     expect(exists(dir, '.git/hooks/pre-push')).toBeFalsy()
@@ -77,7 +77,7 @@ describe('husky', () => {
     install(dir, 'A/B/node_modules/husky')
     const hook = readFile(dir, '.git/modules/A/B/hooks/pre-commit')
 
-    expect(hook).toMatch('cd .')
+    expect(hook).toMatch('cd "."')
 
     uninstall(dir, 'A/B/node_modules/husky')
     expect(exists(dir, '.git/hooks/pre-push')).toBeFalsy()
@@ -91,7 +91,7 @@ describe('husky', () => {
     install(dir, 'A/B/C/node_modules/husky')
     const hook = readFile(dir, '.git/modules/A/B/hooks/pre-commit')
 
-    expect(hook).toMatch('cd C')
+    expect(hook).toMatch('cd "C"')
 
     uninstall(dir, 'A/B/app/node_modules/husky')
     expect(exists(dir, '.git/hooks/pre-push')).toBeFalsy()
@@ -108,7 +108,7 @@ describe('husky', () => {
     install(dir, 'A/B/node_modules/husky')
     const hook = readFile(dir, '.git/worktrees/B/hooks/pre-commit')
 
-    expect(hook).toMatch('cd .')
+    expect(hook).toMatch('cd "."')
 
     uninstall(dir, 'A/B/node_modules/husky')
     expect(exists(dir, '.git/hooks/pre-commit')).toBeFalsy()

--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -66,7 +66,7 @@ function platformSpecific() {
 
 module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
   // On Windows normalize path (i.e. convert \ to /)
-  const normalizedPath = normalize(relativePath)
+  const normalizedPath = normalize(relativePath).replace(/\s/g, '\\ ')
 
   const noVerifyMessage = hookName === 'prepare-commit-msg'
     ? '(cannot be bypassed with --no-verify due to Git specs)'

--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -66,7 +66,7 @@ function platformSpecific() {
 
 module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
   // On Windows normalize path (i.e. convert \ to /)
-  const normalizedPath = normalize(relativePath).replace(/\s/g, '\\ ')
+  const normalizedPath = normalize(relativePath)
 
   const noVerifyMessage = hookName === 'prepare-commit-msg'
     ? '(cannot be bypassed with --no-verify due to Git specs)'
@@ -74,8 +74,7 @@ module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
 
   return [
     stripIndent(
-      `
-      #!/bin/sh
+      `#!/bin/sh
       #husky ${pkg.version}
 
       command_exists () {
@@ -86,7 +85,7 @@ module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
         [ -f package.json ] && cat package.json | grep -q "\\"$1\\"[[:space:]]*:"
       }
 
-      cd ${normalizedPath}
+      cd "${normalizedPath}"
 
       # Check if ${npmScriptName} script is defined, skip if not
       has_hook_script ${npmScriptName} || exit 0`


### PR DESCRIPTION
Spaces in file path for windows are not escaped.

So in the hook file we have something like this:
`cd Solution/05. Web/Service.Web
`

Should be: 
`cd Solution/05.\ Web/Service.Web
`
