### PR TITLE
Support paths which have quotes in them.

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -157,4 +157,20 @@ describe('husky', () => {
     expect(hook).toMatch('husky')
     expect(hook).not.toMatch('ghooks')
   })
+
+  it('should escape apostrophes in the path', () => {
+    mkdir(dir, '.git/hooks')
+    mkdir(dir, 'node_modules/husky')
+
+    // Override home to be a path with an apostrophe in it
+    process.env.HOME = '/User/apotr\'ophe'
+
+    install(dir, 'node_modules/husky')
+    const hook = readFile(dir, '.git/hooks/pre-commit')
+
+    expect(hook).toMatch('load_nvm /User/apotr\\\'ophe/.nvm')
+
+    uninstall(dir, 'node_modules/husky')
+    expect(exists(dir, '.git/hooks/pre-push')).toBeFalsy()
+  })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -158,17 +158,19 @@ describe('husky', () => {
     expect(hook).not.toMatch('ghooks')
   })
 
-  it('should escape apostrophes in the path', () => {
+  it('should escape apostrophes in the path on mac/linux', () => {
     mkdir(dir, '.git/hooks')
     mkdir(dir, 'node_modules/husky')
 
-    // Override home to be a path with an apostrophe in it
-    process.env.HOME = '/User/apotr\'ophe'
+    if (process.platform !== 'win32') {
+      // Override home to be a path with an apostrophe in it
+      process.env.HOME = '/User/apotr\'ophe'
 
-    install(dir, 'node_modules/husky')
-    const hook = readFile(dir, '.git/hooks/pre-commit')
+      install(dir, 'node_modules/husky')
+      const hook = readFile(dir, '.git/hooks/pre-commit')
 
-    expect(hook).toMatch('load_nvm /User/apotr\\\'ophe/.nvm')
+      expect(hook).toMatch('load_nvm /User/apotr\\\'ophe/.nvm')
+    }
 
     uninstall(dir, 'node_modules/husky')
     expect(exists(dir, '.git/hooks/pre-push')).toBeFalsy()

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "tempy": "^0.1.0"
   },
   "dependencies": {
+    "escape-quotes": "^1.0.2",
     "is-ci": "^1.0.10",
     "normalize-path": "^1.0.0",
     "strip-indent": "^2.0.0"

--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const escapeQuotes = require('escape-quotes')
 const normalize = require('normalize-path')
 const stripIndent = require('strip-indent')
 const pkg = require('../../package.json')
@@ -19,7 +20,7 @@ function platformSpecific() {
   } else {
     // Using normalize to support ' in path
     // https://github.com/typicode/husky/issues/117
-    const home = normalize(process.env.HOME)
+    const home = escapeQuotes(normalize(process.env.HOME))
 
     const arr = [
       stripIndent(


### PR DESCRIPTION
Fixes the issue described in https://github.com/typicode/husky/issues/117 where paths with a quote in them will cause the githooks to fail when they run.

(Previous solution used `normalize-path` which only normalizes slashes, so added extra function for escaping quotes.)