### PR TITLE
add the space between 'skipping' word and hookName

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -89,7 +89,7 @@ function installFrom(huskyDir) {
             case UPDATE:
               break
             case SKIP:
-              console.log(`skipping${item.hookName} hook (existing user hook)`)
+              console.log(`skipping ${item.hookName} hook (existing user hook)`)
               break
             case CREATE:
               break


### PR DESCRIPTION
If not, the info will be `skippingpost-commit hook (existing user hook)`,

It will be nice like that `skipping post-commit hook (existing user hook)`