### PR TITLE
Allow stdin during hooks

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -109,6 +109,9 @@ module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
       echo "husky > npm run -s ${npmScriptName} (node \`node -v\`)"
       echo
 
+      # Allows us to read user input below, assigns stdin to keyboard
+      exec < /dev/tty
+
       npm run -s ${npmScriptName} || {
         echo
         echo "husky > ${hookName} hook failed ${noVerifyMessage}"


### PR DESCRIPTION
Enabling interactive prompts in hooks

For more info on interactive hooks, check out [this SO question](https://stackoverflow.com/questions/3417896/how-do-i-prompt-the-user-from-within-a-commit-msg-hook).

In particular, my use-case:

We are currently running tests on `prepush`. We have a quick set of tests, and a longer set of tests. We want to prompt the developer as to which set of tests get run allowing them to move fast on feature branches, but execute the entire test suite at key milestones.