### PR TITLE
Add sendemail-validate githook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -22,3 +22,4 @@ Husky supports all git hooks (https://git-scm.com/docs/githooks). Simply add the
 | prepare-commit-msg | preparecommitmsg |
 | push-to-checkout | pushtocheckout |
 | update | update |
+| sendemail-validate | sendemailvalidate |

--- a/src/hooks.json
+++ b/src/hooks.json
@@ -16,5 +16,6 @@
   "post-update",
   "push-to-checkout",
   "pre-auto-gc",
-  "post-rewrite"
+  "post-rewrite",
+  "sendemail-validate"
 ]


### PR DESCRIPTION
Hello @typicode , and thank you for the great library.

I found [`sendemail-validate`](https://git-scm.com/docs/githooks#_sendemail_validate) hook is missing, and then added.

The hook seems to be added recently.
ref: https://www.spinics.net/lists/git/msg303675.html

I appreciate you if you would check this PR when you have time.