### PR TITLE
Fix `nvm use` running twice on mac

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -26,11 +26,13 @@ function platformSpecific() {
         `
         load_nvm () {
           # If nvm is not loaded, load it
-          command_exists nvm || {
-            export NVM_DIR=${home}/.nvm
-            [ -s "$1/nvm.sh" ] && \. "$1/nvm.sh"
-          }
+          if ! command_exists nvm ; then
+            export NVM_DIR="$1"
+            [ -s "$1/nvm.sh" ] && . "$1/nvm.sh"
+          fi
+        }
 
+        run_nvm () {
           # If nvm has been loaded correctly, use project .nvmrc
           command_exists nvm && [ -f .nvmrc ] && nvm use
         }
@@ -45,7 +47,7 @@ function platformSpecific() {
     arr.push(
       stripIndent(
         `
-        # nvm path with standard installation
+        # Try to load nvm using path of standard installation
         load_nvm ${home}/.nvm`
       )
     )
@@ -54,11 +56,18 @@ function platformSpecific() {
       arr.push(
         stripIndent(
           `
-          # nvm path installed with Brew
+          # Try to load nvm using path when installed with Brew
           load_nvm /usr/local/opt/nvm`
         )
       )
     }
+
+    arr.push(
+      stripIndent(
+        `
+        run_nvm`
+      )
+    )
 
     return arr.join('\n')
   }


### PR DESCRIPTION
This fixes a bug where `nvm use` runs twice on Mac environments:

```bash
$ git commit -am "Test"
Found '/Users/vitorbal/Code/test/.nvmrc' with version <6.2.2>
Now using node v6.2.2 (npm v3.9.5)
Found '/Users/vitorbal/Code/test/.nvmrc' with version <6.2.2>
Now using node v6.2.2 (npm v3.9.5)
husky > npm run -s precommit (node v6.2.2)
```

I assume this is related to the two calls to `load_nvm`:
```bash
# nvm path with standard installation
load_nvm /Users/vitorbal/.nvm

# nvm path installed with Brew
load_nvm /usr/local/opt/nvm
```

The second call only happens if you're in a Mac environment:
```js
    if (process.platform === 'darwin') {
      arr.push(
        stripIndent(
          `
          # Try to load nvm using path when installed with Brew
          load_nvm /usr/local/opt/nvm`
        )
      )
    }
```

---

After the fix:

```bash
$ git commit -am "Test"
Found '/Users/vitorbal/Code/zapier/.nvmrc' with version <6.2.2>
Now using node v6.2.2 (npm v3.9.5)
husky > npm run -s precommit (node v6.2.2)
```