### PR TITLE
Make initiating git command available inside hook

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -94,6 +94,9 @@ module.exports = function getHookScript(hookName, relativePath, npmScriptName) {
       # Export Git hook params
       export GIT_PARAMS="$*"
 
+      # Export git command
+      export GIT_COMMAND=$(ps -ocommand= -p $PPID)
+
       # Run npm script
       echo "husky > npm run -s ${npmScriptName} (node \`node -v\`)"
       echo


### PR DESCRIPTION
Exports the git command that initiated the execution of the hook
available to the hook's code as `process.env.GIT_COMMAND`.

This can be accessed in regular git hooks through `ps -ocommand= -p $PPID`,
but is not available when running hook through an npm script.

It has quite a few use cases. For instance, when guarding against force
pushes in a `pre-push` hook, we can check if `process.env.GIT_COMMAND`
includes `--force ` or `-f`.