### PR TITLE
test: isCI should be defined

### DIFF
--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -146,6 +146,13 @@ describe('install', () => {
   })
 })
 
+describe('isCI', () => {
+  it('should return boolean', () => {
+    expect(isCI).toBeDefined()
+    expect(typeof isCI).toBe('boolean')
+  })
+})
+
 describe('getConf', () => {
   it('should return default conf', () => {
     tempDir = tempy.directory()


### PR DESCRIPTION
Hello,

I was wondering why beta is trying to install on CI server (CircleCI) and failing due to hooks folder does not exist in the CI container. Problem is with the compilation from TS.

``` js
function install(gitDir, huskyDir) {
    console.log('husky > setting up git hooks');
    var userDir = pkgDir.sync(path.join(huskyDir, '..'));
    var conf = getConf(userDir);

    console.log(is_ci_1); // true
    console.log(is_ci_1.default); // undefined

    if (is_ci_1.default && conf.skipCI) {
        console.log('CI detected, skipping Git hooks installation"');
        return;
    }
```