### PR TITLE
feat: add generic script to run on all hooks

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -46,6 +46,7 @@ describe('husky', () => {
 
     expect(hook).toMatch('#husky')
     expect(hook).toMatch('cd "."')
+    expect(hook).toMatch('npm run -s githook -- pre-commit precommit')
     expect(hook).toMatch('npm run -s precommit')
     expect(hook).toMatch('--no-verify')
 


### PR DESCRIPTION
Adds support for a generic `package.json` script name (currently `githook`, but open to alternatives, e.g., `husky` or `hook`) that runs on all hooks, if defined. The current hook name and script name are passed as arguments to this script. This will enable additional behaviors to be abstracted away and delegated to tools like [`react-scripts`](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts) from [`create-react-app`](https://github.com/facebookincubator/create-react-app), without requiring consumers define each hook individually in their own `package.json`.

This would also solve problems for tooling like kentcdodds/nps#97.

Fixes #220.