### PR TITLE
Update docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git commit -m 'Keep calm and commit'
 
 _By default, husky expects your project's `package.json` and your `.git` directory to be at the same level. It can be configured to support monorepos or sub-directories._
 
-Check [documentation](DOCS.md) for more.
+Check [documentation](docs.md) for more.
 
 ## Uninstall
 


### PR DESCRIPTION
Whoops, I clicked the docs link in the README, and it was a 404! Looks like the `docs.md` filename changed, so I updated it here, too.