### PR TITLE
Allow installation in the outer .git directory

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -16,6 +16,14 @@ If you don't want `husky` to automatically install Git hooks, simply set `HUSKY_
 HUSKY_SKIP_INSTALL=true npm install
 ```
 
+## Allow installation in the outer .git directory
+
+If you want to install hooks in outer git repository, set `HUSKY_ALLOW_INSTALL_OUTER` environment variable to `true`.
+
+```
+HUSKY_ALLOW_INSTALL_OUTER=true npm install
+```
+
 ## Multi-package repository (monorepo)
 
 If you have a multi-package repository:

--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -162,6 +162,17 @@ describe('install', () => {
     expect(exists('.git/hooks/pre-commit')).toBeFalsy()
   })
 
+  it('should install hooks in outer the .git dir if HUSKY_ALLOW_INSTALL_OUTER=true', () => {
+    mkdir('.git/hooks')
+    mkdir('subdir/node_modules/husky')
+    writeFile('package.json', pkg)
+
+    process.env.HUSKY_ALLOW_INSTALL_OUTER = 'true'
+    installFrom('subdir/node_modules/husky')
+    delete process.env.HUSKY_ALLOW_INSTALL_OUTER
+    expect(exists('.git/hooks/pre-commit')).toBeTruthy()
+  })
+
   it('should not install hooks in CI server by default', () => {
     mkdir('.git/hooks')
     mkdir('node_modules/husky')

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -116,7 +116,10 @@ export function install(gitDir: string, huskyDir: string, isCI: boolean) {
     return
   }
 
-  if (path.join(userDir, '.git') !== gitDir) {
+  if (
+    path.join(userDir, '.git') !== gitDir &&
+    process.env.HUSKY_ALLOW_INSTALL_OUTER !== 'true'
+  ) {
     console.log(
       `Expecting package.json to be at the same level as .git, skipping Git hooks installation`
     )


### PR DESCRIPTION
Hi! I'm participated in a project which has separated frontend/backend directories.
It has a frontend directory as a subdirectory. And I would like to install hooks from the subdirectory.

```
└───some_backend_repo
    └───.git
    └───frontend
        └───package.json
        └───node_modules
        └─── ....
```

But husky doesn't allow me to install hooks when `package.json` is located in another place of `.git` located.

So I want an opted-in option to install hooks in the outer .git directory.

I implemented to use env variables. So I think this doesn't make bad effects when unwanted.(like #36 )

I hope you to review this pull request.
Thank you.