### PR TITLE
add GIT_STDIN env variable

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -4,9 +4,9 @@
 
 `husky` supports all Git hooks defined [here](https://git-scm.com/docs/githooks).
 
-## Access Git params
+## Access Git params and stdin
 
-You can access them using `GIT_PARAMS` environment variable.
+You can access them using `GIT_PARAMS` and `GIT_STDIN` environment variables.
 
 ## Disable auto-install
 

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -5,6 +5,8 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 # husky
 # v0.15.0-rc.9 darwin
 
+read stdin
+export GIT_STDIN=$stdin
 export GIT_PARAMS=\\"$*\\"
 node_modules/run-node/run-node ./node_modules/husky/lib/runner/bin \`basename \\"$0\\"\`
 "
@@ -15,6 +17,8 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 # husky
 # v0.15.0-rc.9 win32
 
+read stdin
+export GIT_STDIN=$stdin
 export GIT_PARAMS=\\"$*\\"
 node ./node_modules/husky/lib/runner/bin \`basename \\"$0\\"\`
 "

--- a/templates/hook.sh
+++ b/templates/hook.sh
@@ -2,5 +2,7 @@
 {huskyIdentifier}
 # v{version} {platform}
 
+read stdin
+export GIT_STDIN=$stdin
 export GIT_PARAMS="$*"
 {node} ./node_modules/husky/lib/runner/bin `basename "$0"`


### PR DESCRIPTION
From git's [pre-push hook documentation](https://git-scm.com/docs/githooks#_pre_push
):
> Information about what is to be pushed is provided on the hook’s standard input with lines of the form: `<local ref> SP <local sha1> SP <remote ref> SP <remote sha1> LF`

With this PR, stdin is stored in GIT_STDIN env variable so user hooks can access it.

Should fix: https://github.com/typicode/husky/issues/93