### PR TITLE
Update dependent repositories number at readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Alternatively, you can also use any of the files/formats that are supported by [
 * [Kibana](https://github.com/elastic/kibana)
 * [JSON Server](https://github.com/typicode/json-server)
 * [Hotel](https://github.com/typicode/hotel)
-* ... and 12k+ [other awesome repos](https://libraries.io/npm/husky/dependent-repositories) :tada:
+* ... and 18k+ [other awesome repos](https://libraries.io/npm/husky/dependent-repositories) :tada:
 
 ## See also
 


### PR DESCRIPTION
According to https://libraries.io/npm/husky/dependent-repositories, `husky` is used by more than 18k repositories
![image](https://user-images.githubusercontent.com/16997074/37766619-296b40de-2dd0-11e8-9da8-8c8079a313ee.png)
