### PR TITLE
Fix: fatal: Not a git repository: '.git'

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -5,6 +5,7 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 # husky
 # v0.15.0-rc.13 darwin
 
+unset GIT_DIR
 export GIT_PARAMS=\\"$*\\"
 node_modules/run-node/run-node ./node_modules/husky/lib/runner/bin \`basename \\"$0\\"\`
 "
@@ -15,6 +16,7 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 # husky
 # v0.15.0-rc.13 win32
 
+unset GIT_DIR
 export GIT_PARAMS=\\"$*\\"
 node ./node_modules/husky/lib/runner/bin \`basename \\"$0\\"\`
 "

--- a/templates/hook.sh
+++ b/templates/hook.sh
@@ -2,5 +2,6 @@
 {huskyIdentifier}
 # v{version} {platform}
 
+unset GIT_DIR
 export GIT_PARAMS="$*"
 {node} ./node_modules/husky/lib/runner/bin `basename "$0"`


### PR DESCRIPTION
see [https://stackoverflow.com/questions/4043609/getting-fatal-not-a-git-repository-when-using-post-update-hook-to-execut](https://stackoverflow.com/questions/4043609/getting-fatal-not-a-git-repository-when-using-post-update-hook-to-execut)