### PR TITLE
upgrade: run-node to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pkg-dir": "^2.0.0",
     "pupa": "^1.0.0",
     "read-pkg": "^3.0.0",
-    "run-node": "^0.2.0",
+    "run-node": "^1.0.0",
     "slash": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
uses _/usr/bin/env bash_ instead of system level _/bin/bash_