### PR TITLE
fix broken AppVeyor URL; use absolute URL for docs.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# husky [![](https://img.shields.io/npm/dm/husky.svg?style=flat)](https://www.npmjs.org/package/husky) [![Mac/Linux Build Status](https://img.shields.io/travis/typicode/husky/dev.svg?label=Mac%20OSX%20%26%20Linux)](https://travis-ci.org/typicode/husky) [![Windows Build status](https://img.shields.io/appveyor/ci/typicode/husky/dev.svg?label=Windows)](https://ci.appveyor.com/project/typicode/husky/dev/master)
+# husky [![](https://img.shields.io/npm/dm/husky.svg?style=flat)](https://www.npmjs.org/package/husky) [![Mac/Linux Build Status](https://img.shields.io/travis/typicode/husky/dev.svg?label=Mac%20OSX%20%26%20Linux)](https://travis-ci.org/typicode/husky) [![Windows Build status](https://img.shields.io/appveyor/ci/typicode/husky/dev.svg?label=Windows)](https://ci.appveyor.com/project/typicode/husky/dev)
 
 > Git hooks made easy
 
@@ -31,7 +31,7 @@ git commit -m 'Keep calm and commit'
 
 _By default, husky expects your project's `package.json` and your `.git` directory to be at the same level. It can be configured to support monorepos or sub-directories._
 
-Check [documentation](docs.md) for more.
+Check [documentation](https://github.com/typicode/husky/blob/dev/docs.md) for more.
 
 ## Uninstall
 


### PR DESCRIPTION
This corrects a couple issues I saw.

- The AppVeyor URL was broken.
- A reader of `README.md` might not be reading it on GitHub, so use an absolute URL to `docs.md`.