### PR TITLE
Prevent package normalizing

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -7,7 +7,7 @@ import getConf from '../getConf'
  */
 export default function([, scriptPath, hookName = '']: string[]): number {
   const [cwd] = scriptPath.split('node_modules')
-  const pkg = readPkg.sync(cwd)
+  const pkg = readPkg.sync(cwd, { normalize: false })
 
   const config = getConf(cwd)
 


### PR DESCRIPTION
Currently date-fns has this `package.json` and husky fails because the version is invalid.

```js
{
  "version": "DON'T CHANGE; IT'S SET AUTOMATICALLY DURING DEPLOYMENT; ALSO, USE YARN FOR DEVELOPMENT"
}
```

I think that husky shouldn't be cared about package linting. Husky is used by user for any kind of linting and shouldn't force user to anything.