### PR TITLE
Link directly to stable readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Husky can prevent bad `git commit`, `git push` and more :dog: _woof!_
 
-_You're viewing the documentation for the next version of husky, click [here](https://github.com/typicode/husky/tree/v0.14.3) if you prefer to view docs for the stable version (`v0.14.3`)_
+_You're viewing the documentation for the next version of husky, click [here](https://github.com/typicode/husky/tree/v0.14.3#husky----) if you prefer to view docs for the stable version (`v0.14.3`)_
 
 ## Install
 


### PR DESCRIPTION
The `README` of the dev branch is linking to the stable branch, but it would be neater if it linked directly to the start of the stable branch's `README`.
