### PR TITLE
Add info about husky-upgrade with npx to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,14 @@ Simply move your existing hooks to `husky.hooks` field and use raw Git hooks nam
 
 Alternatively, you can run the following command which will do the same automatically for you ;)
 
-```
+```sh
 ./node_modules/.bin/husky-upgrade
+```
+
+Or with `npx`:
+
+```sh
+npx husky husky-upgrade
 ```
 
 Starting with `1.0.0`, you can also configure hooks using `.huskyrc`, `.huskyrc.json` or `.huskyrc.js` file.


### PR DESCRIPTION
In certain scenarios `node_modules` might not be in the current directory (i.e. `yarn` workspaces, user's cwd is not the root of the package, or `husky` installed somewhere higher up).

`npx` will work so long as the user is able to connect to the `npm` registry, so it's good to note how to do `husky-upgrade` through it.