### PR TITLE
`husky-upgrade` replace GIT_PARAMS with HUSKY_GIT_PARAMS

### DIFF
--- a/src/upgrader/__tests__/index.ts
+++ b/src/upgrader/__tests__/index.ts
@@ -12,6 +12,7 @@ describe('upgrade', () => {
       filename,
       JSON.stringify({
         scripts: {
+          commitmsg: 'echo $GIT_PARAMS GIT_PARAMS HUSKY_GIT_PARAMS',
           precommit: 'npm test'
         }
       }),
@@ -23,6 +24,8 @@ describe('upgrade', () => {
     expect(JSON.parse(fs.readFileSync(filename, 'utf-8'))).toEqual({
       husky: {
         hooks: {
+          'commit-msg':
+            'echo $HUSKY_GIT_PARAMS HUSKY_GIT_PARAMS HUSKY_GIT_PARAMS',
           'pre-commit': 'npm test'
         }
       },

--- a/src/upgrader/index.ts
+++ b/src/upgrader/index.ts
@@ -51,7 +51,10 @@ export default function upgrade(cwd: string) {
       if (script) {
         delete pkg.scripts[name]
         const newName = hookList[name]
-        pkg.husky.hooks[newName] = script
+        pkg.husky.hooks[newName] = script.replace(
+          /\bGIT_PARAMS\b/g,
+          'HUSKY_GIT_PARAMS'
+        )
         console.log(`moved scripts.${name} to husky.hooks.${newName}`)
       }
     })


### PR DESCRIPTION
Thanks for providing a nice tool `husky-upgrade`!

I'm using the tool [`commitlint`](https://github.com/marionebl/commitlint), and my `package.json` is below:

```json
{
  "scripts": {
    "commitmsg": "commitlint -E GIT_PARAMS"
  }
}
```

I'm so happy that `husky-upgrade` will update `GIT_PARAMS` to `HUSKY_GIT_PARAMS`, like this:

```json
{
  "husky": {
    "hooks": {
      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
    }
  }
}
```
