### PR TITLE
upgrader: Add trailing newline to package.json

### DIFF
--- a/src/upgrader/index.ts
+++ b/src/upgrader/index.ts
@@ -57,7 +57,7 @@ export default function upgrade(cwd: string) {
     })
 
     // Update package.json
-    fs.writeFileSync(pkgFile, JSON.stringify(pkg, null, 2), 'utf-8')
+    fs.writeFileSync(pkgFile, `${JSON.stringify(pkg, null, 2)}\n`, 'utf-8')
     console.log(`husky > done`)
   }
 }


### PR DESCRIPTION
By default npm includes a trailing newline when it writes the `package.json`. this preserves that behavior to not cause churn in the file in the most common case.

https://github.com/npm/cli/blob/4c65cd952bc8627811735bea76b9b110cc4fc80e/lib/install/update-package-json.js#L48