### PR TITLE
Do not fail just because "hooks" foder does no exists yet

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -174,9 +174,7 @@ export function install(
   }
 
   if (!fs.existsSync(path.join(resolvedGitDir, 'hooks'))) {
-    console.log(
-      `Can't find hooks directory in ${resolvedGitDir}, creating it.`
-    )
+    console.log(`Can't find hooks directory in ${resolvedGitDir}, creating it.`)
     fs.mkdirSync(path.join(resolvedGitDir, 'hooks'))
   }
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -175,15 +175,9 @@ export function install(
 
   if (!fs.existsSync(path.join(resolvedGitDir, 'hooks'))) {
     console.log(
-      `Can't find hooks directory in ${resolvedGitDir}, skipping Git hooks installation.`
+      `Can't find hooks directory in ${resolvedGitDir}, creating it.`
     )
-    console.log(
-      `Please create ${path.join(
-        resolvedGitDir,
-        'hooks'
-      )} directory and reinstall husky.`
-    )
-    return
+    fs.mkdirSync(path.join(resolvedGitDir, 'hooks'))
   }
 
   // Create hooks


### PR DESCRIPTION
The way we all use husky is by "npm install".

It is very annoying when for a reason, the hooks does not install. Then we have to go to every developers to ask them to check their install. Which is very not convenient.

This proposal, is to remove one fail, which is, in my opinion, not so difficult to handle.
Is ".git" exists, but ".git/hooks" does not, instead of skipping installation, we create the folder. Not a big deal, but sooooo annoying the current way.