### PR TITLE
don't default to run-node, use 'node' if it works

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -8,13 +8,16 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
+node=node
 
 if ! command -v node >/dev/null 2>&1; then
   echo \\"Can't find node in PATH, trying to find a node binary on your system\\"
+  # Fall-back to run-node since plain node was not found.
+  node=node_modules/run-node/run-node
 fi
 
 if [ -f $scriptPath ]; then
-  node_modules/run-node/run-node $scriptPath $hookName \\"$gitParams\\"
+  $node $scriptPath $hookName \\"$gitParams\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"
   echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
@@ -30,9 +33,10 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
+node=node
 
 if [ -f $scriptPath ]; then
-  node $scriptPath $hookName \\"$gitParams\\"
+  $node $scriptPath $hookName \\"$gitParams\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"
   echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -21,17 +21,20 @@ ${huskyIdentifier}
 scriptPath="${script}.js"
 hookName=\`basename "$0"\`
 gitParams="$*"
+node=node
 ${
   platform !== 'win32'
     ? `
 if ! command -v node >/dev/null 2>&1; then
   echo "Can't find node in PATH, trying to find a node binary on your system"
+  # Fall-back to run-node since plain node was not found.
+  node=${node}
 fi
 `
     : ''
 }
 if [ -f $scriptPath ]; then
-  ${node} $scriptPath $hookName "$gitParams"
+  $node $scriptPath $hookName "$gitParams"
 else
   echo "Can't find Husky, skipping $hookName hook"
   echo "You can reinstall it using 'npm install husky --save-dev' or delete this hook"
@@ -53,7 +56,7 @@ export default function(
 ) {
   const runNodePath = slash(path.relative(rootDir, requireRunNodePath))
 
-  // On Windows do not rely on run-node
+  // On Windows do not fall-back to run-node
   const node = platform === 'win32' ? 'node' : runNodePath
 
   const { version } = JSON.parse(


### PR DESCRIPTION
If `node` works, we will not bother with `run-node` on non-windows
platforms, since `run-node` requires `bash` and operating systems like
OpenBSD and FreeBSD, as well as minimal docker images like Alpine,
don't have bash in their base installations.