### PR TITLE
update jest test to use MockInstance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@types/jest": {
-      "version": "23.3.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.2.tgz",
-      "integrity": "sha512-D1xlXHZpDonVX+VJ28XtcD5xlu8ex6Fc4cQNnrm2wJvlQnbec9RedhCrhQr6kRAE9XWHSec+JPuTmqJ9jC0qsA==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.3.tgz",
+      "integrity": "sha512-G6EBrbjWDfmIpYu8UcRBOhwtDiYaLj5N5jUR5rx0YvbKxRBhXPZVLUmtfShewSUNKiQwpHavpML69a2WMbIlEQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1964,12 +1964,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1984,17 +1986,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2111,7 +2116,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2123,6 +2129,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2137,6 +2144,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2144,12 +2152,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2168,6 +2178,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2248,7 +2259,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2260,6 +2272,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2381,6 +2394,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/execa": "^0.9.0",
     "@types/find-up": "^2.1.1",
     "@types/get-stdin": "^5.0.1",
-    "@types/jest": "^23.3.2",
+    "@types/jest": "^23.3.3",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^10.11.3",
     "del": "^3.0.0",

--- a/src/runner/__tests__/index.ts
+++ b/src/runner/__tests__/index.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import * as tempy from 'tempy'
 import index from '../'
 
-let spy: jest.SpyInstance
+let spy: jest.MockInstance<{}>
 
 function getScriptPath(dir: string) {
   return path.join(dir, 'node_modules/husky/runner/index.js')


### PR DESCRIPTION
on jest version 23.6 -- running `jest -u` on master yields 1 failed test in the Test Suites:
 
```
FAIL  src/runner/__tests__/index.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/runner/__tests__/index.ts:8:15 - error TS2694: Namespace 'jest' has no exported member 'SpyInstance'.

    8 let spy: jest.SpyInstance
                    ~~~~~~~~~~~
```

This seems to stem from a recent change in `jest` and `@types/jest`, reflected
by this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29306