### PR TITLE
Print debug message at hook start

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -9,6 +9,13 @@ scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
 
+if [[ ! -z \\"\${HUSKY_DEBUG}\\" ]]; then
+  echo \\"
+husky:debug $hookName hook started...
+\\"
+fi
+
+
 if ! command -v node >/dev/null 2>&1; then
   echo \\"Can't find node in PATH, trying to find a node binary on your system\\"
 fi
@@ -30,6 +37,13 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
+
+if [[ ! -z \\"\${HUSKY_DEBUG}\\" ]]; then
+  echo \\"
+husky:debug $hookName hook started...
+\\"
+fi
+
 
 if [ -f $scriptPath ]; then
   node $scriptPath $hookName \\"$gitParams\\"

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -21,6 +21,11 @@ ${huskyIdentifier}
 scriptPath="${script}.js"
 hookName=\`basename "$0"\`
 gitParams="$*"
+
+if [[ ! -z "$\{HUSKY_DEBUG\}" ]]; then
+  echo "\nhusky:debug $hookName hook started...\n"
+fi
+
 ${
   platform !== 'win32'
     ? `


### PR DESCRIPTION
Closes #371

This PR prints added ability to echo a message at the beginning of the shell script when `HUSKY_DEBUG` is set.

**Example**

```
$ HUSKY_DEBUG=true git commit -m 'accidental commit'

husky:debug pre-commit hook started...

husky > pre-commit (node v10.11.0)

> husky@1.1.1 test /Users/waseem/Repositories/husky
> npm run lint && jest


> husky@1.1.1 lint /Users/waseem/Repositories/husky
> tslint 'src/**/*.ts'

...
```