### PR TITLE
feat: store hook name in HUSKY_GIT_HOOK environment variable

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -2,7 +2,7 @@
 
 ## Supported hooks
 
-`husky` supports all Git hooks defined [here](https://git-scm.com/docs/githooks).
+`husky` supports all Git hooks defined [here](https://git-scm.com/docs/githooks). Husky stores the hook name in the `HUSKY_GIT_HOOK` environment variable so it can be accessed from hook scripts.
 
 Server-side hooks (`pre-receive`, `update` and `post-receive`) aren't supported.
 

--- a/src/runner/__tests__/index.ts
+++ b/src/runner/__tests__/index.ts
@@ -38,7 +38,9 @@ describe('run', () => {
     const status = await index(['', getScriptPath(dir), 'pre-commit'])
     expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
       cwd: dir,
-      env: {},
+      env: {
+        HUSKY_GIT_HOOK: 'pre-commit'
+      },
       stdio: 'inherit'
     })
     expect(status).toBe(0)
@@ -63,7 +65,9 @@ describe('run', () => {
     const status = await index(['', getScriptPath(subDir), 'pre-commit'])
     expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
       cwd: subDir,
-      env: {},
+      env: {
+        HUSKY_GIT_HOOK: 'pre-commit'
+      },
       stdio: 'inherit'
     })
     expect(status).toBe(0)
@@ -103,7 +107,9 @@ describe('run', () => {
     const status = await index(['', getScriptPath(dir), 'pre-commit'])
     expect(execa.shellSync).toHaveBeenCalledWith('echo fail && exit 2', {
       cwd: dir,
-      env: {},
+      env: {
+        HUSKY_GIT_HOOK: 'pre-commit'
+      },
       stdio: 'inherit'
     })
     expect(status).toBe(2)
@@ -124,7 +130,36 @@ describe('run', () => {
     const status = await index(['', getScriptPath(dir), 'pre-commit'])
     expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
       cwd: dir,
-      env: {},
+      env: {
+        HUSKY_GIT_HOOK: 'pre-commit'
+      },
+      stdio: 'inherit'
+    })
+    expect(status).toBe(0)
+  })
+
+  it('should set HUSKY_GIT_HOOK', async () => {
+    const dir = tempy.directory()
+
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({
+        husky: {
+          hooks: {
+            'pre-commit': 'echo success'
+          }
+        }
+      })
+    )
+
+    const status = await index(['', getScriptPath(dir), 'pre-commit'], () =>
+      Promise.resolve('foo')
+    )
+    expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
+      cwd: dir,
+      env: {
+        HUSKY_GIT_HOOK: 'pre-commit'
+      },
       stdio: 'inherit'
     })
     expect(status).toBe(0)
@@ -150,6 +185,7 @@ describe('run', () => {
     expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
       cwd: dir,
       env: {
+        HUSKY_GIT_HOOK: 'pre-push',
         HUSKY_GIT_STDIN: 'foo'
       },
       stdio: 'inherit'
@@ -181,6 +217,7 @@ describe('run', () => {
     expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
       cwd: dir,
       env: {
+        HUSKY_GIT_HOOK: 'commit-msg',
         HUSKY_GIT_PARAMS: 'git fake param'
       },
       stdio: 'inherit'

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -7,6 +7,7 @@ import getConf from '../getConf'
 export interface IEnv extends NodeJS.ProcessEnv {
   HUSKY_GIT_STDIN?: string
   HUSKY_GIT_PARAMS?: string
+  HUSKY_GIT_HOOK?: string
 }
 
 /**
@@ -38,6 +39,10 @@ export default async function run(
   // Run command
   try {
     const env: IEnv = {}
+
+    if (hookName) {
+      env.HUSKY_GIT_HOOK = hookName
+    }
 
     if (HUSKY_GIT_PARAMS) {
       env.HUSKY_GIT_PARAMS = HUSKY_GIT_PARAMS


### PR DESCRIPTION
Add `HUSKY_GIT_HOOK` environment variable so hook scripts can easily see which hook is being executed.

Fixes https://github.com/typicode/husky/issues/380