### PR TITLE
Ignore git hooks if package.json file was removed

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -5,6 +5,7 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 # husky
 # v1.1.2 darwin
 
+configPath=\\"package.json\\"
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
@@ -15,6 +16,10 @@ fi
 
 if ! command -v node >/dev/null 2>&1; then
   echo \\"Can't find node in PATH, trying to find a node binary on your system\\"
+fi
+
+if [ -f $scriptPath ]; then
+  exit 0
 fi
 
 if [ -f $scriptPath ]; then
@@ -31,12 +36,17 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 # husky
 # v1.1.2 win32
 
+configPath=\\"package.json\\"
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
 gitParams=\\"$*\\"
 
 if [ \\"\${HUSKY_DEBUG}\\" = \\"true\\" ]; then
   echo \\"husky:debug $hookName hook started...\\"
+fi
+
+if [ -f $scriptPath ]; then
+  exit 0
 fi
 
 if [ -f $scriptPath ]; then

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -18,7 +18,7 @@ if ! command -v node >/dev/null 2>&1; then
   echo \\"Can't find node in PATH, trying to find a node binary on your system\\"
 fi
 
-if [ -f $configPath ]; then
+if [ ! -f $configPath ]; then
   exit 0
 fi
 
@@ -45,7 +45,7 @@ if [ \\"\${HUSKY_DEBUG}\\" = \\"true\\" ]; then
   echo \\"husky:debug $hookName hook started...\\"
 fi
 
-if [ -f $configPath ]; then
+if [ ! -f $configPath ]; then
   exit 0
 fi
 

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -18,7 +18,7 @@ if ! command -v node >/dev/null 2>&1; then
   echo \\"Can't find node in PATH, trying to find a node binary on your system\\"
 fi
 
-if [ -f $scriptPath ]; then
+if [ -f $configPath ]; then
   exit 0
 fi
 
@@ -45,7 +45,7 @@ if [ \\"\${HUSKY_DEBUG}\\" = \\"true\\" ]; then
   echo \\"husky:debug $hookName hook started...\\"
 fi
 
-if [ -f $scriptPath ]; then
+if [ -f $configPath ]; then
   exit 0
 fi
 

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -35,7 +35,7 @@ fi
 `
     : ''
 }
-if [ -f $configPath ]; then
+if [ ! -f $configPath ]; then
   exit 0
 fi
 

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -18,6 +18,7 @@ const render = ({ node, platform, script, version }: IContext) => `#!/bin/sh
 ${huskyIdentifier}
 # v${version} ${platform}
 
+configPath="package.json"
 scriptPath="${script}.js"
 hookName=\`basename "$0"\`
 gitParams="$*"
@@ -34,6 +35,9 @@ fi
 `
     : ''
 }
+if [ -f $scriptPath ]; then
+  exit 0
+fi
 if [ -f $scriptPath ]; then
   ${node} $scriptPath $hookName "$gitParams"
 else

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -35,7 +35,7 @@ fi
 `
     : ''
 }
-if [ -f $scriptPath ]; then
+if [ -f $configPath ]; then
   exit 0
 fi
 

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -38,6 +38,7 @@ fi
 if [ -f $scriptPath ]; then
   exit 0
 fi
+
 if [ -f $scriptPath ]; then
   ${node} $scriptPath $hookName "$gitParams"
 else


### PR DESCRIPTION
If Husky was added to exists project than all older branches don't have a package.json file. Therefore git action in the old branch gets an error because run.js can't read the package.json file and git action is not executed. 

Of course, you can merge with a master branch, but for instance, if you decided to build the previous release from the old branch you should either delete hooks directory or add the package.json file.