### PR TITLE
Add generated by informations in hook script

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -6,7 +6,7 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 12/22/2016, 12:36:07 AM
+#   At: <locale date string>
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package
@@ -42,7 +42,7 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 12/22/2016, 12:36:07 AM
+#   At: <locale date string>
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -3,7 +3,17 @@
 exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 "#!/bin/sh
 # husky
-# v1.1.4 darwin
+
+# Hook created by Husky
+#   Version: 1.1.4
+#   At: 2018-11-19
+#   See: https://github.com/typicode/husky#readme
+#
+# From npm package
+#   Name: foo-package
+#   Directory: /home/typicode/projects/foo-package
+#   Homepage: https://github.com/foo/foo-package
+
 
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
@@ -30,7 +40,17 @@ fi
 exports[`hookScript should match snapshot (Windows) 1`] = `
 "#!/bin/sh
 # husky
-# v1.1.4 win32
+
+# Hook created by Husky
+#   Version: 1.1.4
+#   At: 2018-11-19
+#   See: https://github.com/typicode/husky#readme
+#
+# From npm package
+#   Name: foo-package
+#   Directory: /home/typicode/projects/foo-package
+#   Homepage: https://github.com/foo/foo-package
+
 
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -8,7 +8,7 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 #   Version: 1.1.4
 #   At: <locale date string>
 #   See: https://github.com/typicode/husky#readme
-#
+
 # From npm package
 #   Name: foo-package
 #   Directory: /home/typicode/projects/foo-package
@@ -44,7 +44,7 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 #   Version: 1.1.4
 #   At: <locale date string>
 #   See: https://github.com/typicode/husky#readme
-#
+
 # From npm package
 #   Name: foo-package
 #   Directory: /home/typicode/projects/foo-package

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -6,14 +6,13 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 2018-11-19
+#   At: 8/19/1975, 5:15:30 PM
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package
 #   Name: foo-package
 #   Directory: /home/typicode/projects/foo-package
 #   Homepage: https://github.com/foo/foo-package
-
 
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`
@@ -43,14 +42,13 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 2018-11-19
+#   At: 8/19/1975, 5:15:30 PM
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package
 #   Name: foo-package
 #   Directory: /home/typicode/projects/foo-package
 #   Homepage: https://github.com/foo/foo-package
-
 
 scriptPath=\\"node_modules/husky/run.js\\"
 hookName=\`basename \\"$0\\"\`

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -6,7 +6,7 @@ exports[`hookScript should match snapshot (OS X/Linux) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 8/19/1975, 5:15:30 PM
+#   At: 12/22/2016, 12:36:07 AM
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package
@@ -42,7 +42,7 @@ exports[`hookScript should match snapshot (Windows) 1`] = `
 
 # Hook created by Husky
 #   Version: 1.1.4
-#   At: 8/19/1975, 5:15:30 PM
+#   At: 12/22/2016, 12:36:07 AM
 #   See: https://github.com/typicode/husky#readme
 #
 # From npm package

--- a/src/installer/__tests__/getScript.ts
+++ b/src/installer/__tests__/getScript.ts
@@ -7,6 +7,14 @@ const huskyDir = '/home/typicode/project/node_modules/husky'
 // In order to make the test deterministic on AppVeyor, the value is hardcoded
 const runNodePath = '/home/typicode/project/node_modules/run-node/run-node'
 
+// Faking env variable
+process.env = {
+  ...process.env,
+  PWD: '/home/typicode/projects/foo-package',
+  npm_package_homepage: 'https://github.com/foo/foo-package',
+  npm_package_name: 'foo-package'
+}
+
 describe('hookScript', () => {
   it('should match snapshot (OS X/Linux)', () => {
     const script = getScript(rootDir, huskyDir, runNodePath, 'darwin')

--- a/src/installer/__tests__/getScript.ts
+++ b/src/installer/__tests__/getScript.ts
@@ -1,13 +1,7 @@
 import getScript from '../getScript'
 
-// Mock Date to be always constant
-const constantDate = new Date('August 19, 1975 23:15:30 GMT+07:00')
-global.Date = class extends Date {
-  constructor() {
-    super()
-    return constantDate
-  }
-} as DateConstructor
+// Mock Date to have deterministic test
+Date.now = jest.fn(() => 1482363367071)
 
 const rootDir = '/home/typicode/project'
 const huskyDir = '/home/typicode/project/node_modules/husky'

--- a/src/installer/__tests__/getScript.ts
+++ b/src/installer/__tests__/getScript.ts
@@ -1,5 +1,14 @@
 import getScript from '../getScript'
 
+// Mock Date to be always constant
+const constantDate = new Date('August 19, 1975 23:15:30 GMT+07:00')
+global.Date = class extends Date {
+  constructor() {
+    super()
+    return constantDate
+  }
+} as DateConstructor
+
 const rootDir = '/home/typicode/project'
 const huskyDir = '/home/typicode/project/node_modules/husky'
 

--- a/src/installer/__tests__/getScript.ts
+++ b/src/installer/__tests__/getScript.ts
@@ -18,6 +18,17 @@ process.env = {
   npm_package_name: 'foo-package'
 }
 
+// Mock Date.toLocaleString
+global.Date = class extends Date {
+  constructor() {
+    super()
+  }
+
+  public toLocaleString() {
+    return '<locale date string>'
+  }
+} as DateConstructor
+
 describe('hookScript', () => {
   it('should match snapshot (OS X/Linux)', () => {
     const script = getScript(rootDir, huskyDir, runNodePath, 'darwin')

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -39,7 +39,7 @@ ${huskyIdentifier}
 #   Version: ${version}
 #   At: ${createdAt}
 #   See: ${homepage}
-#
+
 # From npm package
 #   Name: ${pkgName}
 #   Directory: ${pkgDirectory}

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -104,8 +104,7 @@ export default function(
   )
 
   // created at
-  const now = Date.now()
-  const createdAt = new Date(now).toLocaleString()
+  const createdAt = new Date().toLocaleString()
 
   // Render script
   return render({


### PR DESCRIPTION
To make debugging easier, add more info about husky and which package installed it:

```
# Hook created by Husky
#   Version: 1.1.4
#   At: <locale date string>
#   See: https://github.com/typicode/husky#readme

# From npm package
#   Name: foo-package
#   Directory: /home/typicode/projects/foo-package
#   Homepage: https://github.com/foo/foo-package
```

Thanks to @garybernhardt for the idea :+1: 