### PR TITLE
feat(runner): support hooks with multiple commands

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -2,6 +2,9 @@
   "skipCI": false,
   "hooks": {
     "pre-commit": "npm test",
-    "post-checkout": "rm -f ci-post-checkout && echo \"running CI post-checkout test\" && node scripts/ci-post-checkout-script"
+    "post-checkout": [
+      "rm -f ci-post-checkout",
+      "node scripts/ci-post-checkout-script"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ npm install husky --save-dev
   "husky": {
     "hooks": {
       "pre-commit": "npm test",
-      "pre-push": "npm test",
+      "pre-push": [
+        "npm lint",
+        "npm test"
+      ],
       "...": "..."
     }
   }

--- a/src/runner/__tests__/index.ts
+++ b/src/runner/__tests__/index.ts
@@ -44,6 +44,34 @@ describe('run', () => {
     expect(status).toBe(0)
   })
 
+  it('should run working commands and return 0 status', async () => {
+    const dir = tempy.directory()
+
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({
+        husky: {
+          hooks: {
+            'pre-commit': ['echo success', 'echo success2']
+          }
+        }
+      })
+    )
+
+    const status = await index(['', getScriptPath(dir), 'pre-commit'])
+    expect(execa.shellSync).toHaveBeenCalledWith('echo success', {
+      cwd: dir,
+      env: {},
+      stdio: 'inherit'
+    })
+    expect(execa.shellSync).toHaveBeenCalledWith('echo success2', {
+      cwd: dir,
+      env: {},
+      stdio: 'inherit'
+    })
+    expect(status).toBe(0)
+  })
+
   it('should run working command and return 0 status when husky is installed in a sub directory', async () => {
     const dir = tempy.directory()
     const subDir = path.join(dir, 'A/B')

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -29,13 +29,13 @@ export default async function run(
   }
   const config = getConf(cwd)
 
-  const command: string | undefined =
+  let commands: string | string[] | undefined =
     config && config.hooks && config.hooks[hookName]
 
   const oldCommand: string | undefined =
     pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
 
-  // Run command
+  // Run commands
   try {
     const env: IEnv = {}
 
@@ -51,9 +51,18 @@ export default async function run(
       env.HUSKY_GIT_STDIN = await getStdinFn()
     }
 
-    if (command) {
-      console.log(`husky > ${hookName} (node ${process.version})`)
-      execa.shellSync(command, { cwd, env, stdio: 'inherit' })
+    if (commands) {
+      if (!Array.isArray(commands)) {
+        commands = [commands]
+      }
+
+      commands.forEach((command: string) => {
+        console.log(
+          `husky > ${hookName} > ${command} (node ${process.version})`
+        )
+        execa.shellSync(command, { cwd, env, stdio: 'inherit' })
+      })
+
       return 0
     }
 


### PR DESCRIPTION
Added support to run hooks with multiple commands, except for old commands.

Related issues: #330 #319 