### PR TITLE
Enable stdin if terminal

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -29,6 +29,9 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 if [ -f $scriptPath ]; then
+  if [ -t 1 ]; then
+    exec < /dev/tty
+  fi
   if [ -f ~/.huskyrc ]; then
     debug \\"source ~/.huskyrc\\"
     source ~/.huskyrc
@@ -66,6 +69,9 @@ debug() {
 debug \\"$hookName hook started...\\"
 
 if [ -f $scriptPath ]; then
+  if [ -t 1 ]; then
+    exec < /dev/tty
+  fi
   if [ -f ~/.huskyrc ]; then
     debug \\"source ~/.huskyrc\\"
     source ~/.huskyrc

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -64,6 +64,9 @@ fi
     : ''
 }
 if [ -f $scriptPath ]; then
+  if [ -t 1 ]; then
+    exec < /dev/tty
+  fi
   if [ -f ${huskyrc} ]; then
     debug "source ${huskyrc}"
     source ${huskyrc}


### PR DESCRIPTION
This PR enables `stdin` if hook is running in terminal.

Since there are many PRs regarding this feature, some on old code, I'm creating this new one. In order for everyone who contributed to get credits, I'll add [`Co-authored-by`](https://help.github.com/articles/creating-a-commit-with-multiple-authors/) fields to the commit.

I've never tried this approach before. but from my understanding it should appear in your contribution graph as if your PRs were merged 🤞

In any case, credits and thanks go to @jesstelford, @joelgallant, @tanhauhau and @ikokostya for this feature.

Note: to be able to add you, GitHub seems to need an email as mentioned [here](https://help.github.com/articles/creating-a-commit-with-multiple-authors/), please send it to me using my mail or DM me on Twitter. I'll leave this PR open for a week.