### PR TITLE
Add configuration for choosing the branches for which the hook commands should be executed

### DIFF
--- a/src/runner/__tests__/index.ts
+++ b/src/runner/__tests__/index.ts
@@ -22,7 +22,7 @@ describe('run', () => {
     spy.mockRestore()
   })
 
-  describe('with no specified target branch', () => {
+  describe('with no specified active branch', () => {
     it('should run working command and return 0 status', async () => {
       const dir = tempy.directory()
 
@@ -196,12 +196,12 @@ describe('run', () => {
     })
   })
 
-  describe('with a specified target branch', () => {
+  describe('with specified active branches', () => {
     beforeEach(() => {
       jest.mock('execa')
     })
 
-    it('should run command if target and current branches match', async () => {
+    it('should run command if current branch is active', async () => {
       const dir = tempy.directory()
 
       fs.writeFileSync(
@@ -209,15 +209,15 @@ describe('run', () => {
         JSON.stringify({
           husky: {
             hooks: {
-              'pre-commit': 'echo success',
-              'target-branch': 'target-branch'
+              'active-branches': ['active-branch'],
+              'pre-commit': 'echo success'
             }
           }
         })
       )
 
       execa.shellSync = jest.fn(() => ({
-        stdout: 'target-branch'
+        stdout: 'active-branch'
       }))
 
       const status = await index(['', getScriptPath(dir), 'pre-commit'])
@@ -237,7 +237,7 @@ describe('run', () => {
       expect(status).toBe(0)
     })
 
-    it("should not run command if target and current branches don't match", async () => {
+    it('should not run command if current branch is not active', async () => {
       const dir = tempy.directory()
 
       fs.writeFileSync(
@@ -245,15 +245,15 @@ describe('run', () => {
         JSON.stringify({
           husky: {
             hooks: {
-              'pre-commit': 'echo success',
-              'target-branch': 'target-branch'
+              'active-branches': ['mismatching-branch'],
+              'pre-commit': 'echo success'
             }
           }
         })
       )
 
       execa.shellSync = jest.fn(() => ({
-        stdout: 'mismatching-branch'
+        stdout: 'active-branch'
       }))
 
       const status = await index(['', getScriptPath(dir), 'pre-commit'])

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -35,6 +35,17 @@ export default async function run(
   const oldCommand: string | undefined =
     pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
 
+  const targetBranch: string | undefined =
+    config && config.hooks && config.hooks['target-branch']
+
+  const currentBranch = execa.shellSync(
+    'env -i git rev-parse --abbrev-ref HEAD'
+  ).stdout
+
+  if (targetBranch && targetBranch !== currentBranch) {
+    return 0
+  }
+
   // Run command
   try {
     const env: IEnv = {}

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -35,7 +35,7 @@ export default async function run(
   const oldCommand: string | undefined =
     pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
 
-  const activeBranches: string | undefined =
+  const activeBranches: Array<string> | undefined =
     config && config.hooks && config.hooks['active-branches']
 
   const currentBranch = execa.shellSync(

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -35,14 +35,14 @@ export default async function run(
   const oldCommand: string | undefined =
     pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
 
-  const targetBranch: string | undefined =
-    config && config.hooks && config.hooks['target-branch']
+  const activeBranches: string | undefined =
+    config && config.hooks && config.hooks['active-branches']
 
   const currentBranch = execa.shellSync(
     'env -i git rev-parse --abbrev-ref HEAD'
   ).stdout
 
-  if (targetBranch && targetBranch !== currentBranch) {
+  if (activeBranches && !activeBranches.includes(currentBranch)) {
     return 0
   }
 


### PR DESCRIPTION
## Description
Adding a simple configuration field for when you don't want to run the configured hooks for every branch.

There's a check verifying if the hook commands should be executed for the current working branch.

## How to use
Add the key `active-branches` and set an array value with the name of the branches for which you want the hooks executed.

Example:
```
// package.json
{
  "husky": {
    "hooks": {
      "pre-commit": "npm test",
      "pre-push": "npm test",
      "active-branches": ["master", "staging"],
      "...": "..."
    }
  }
}
```