### PR TITLE
Allow husky configs from child package.json

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -27,6 +27,16 @@ if ! command -v node >/dev/null 2>&1; then
   echo \\"Info: Can't find node in PATH, trying to find a node binary on your system\\"
 fi
 
+
+# Git hooks change the PWD to be the dir where the .git folder lives. GIT_PREFIX
+# stores the original location of where the hook was executed from. This allows
+# us to work out the original PWD.
+gitCwd=\\"$GIT_PREFIX\\"
+if [ ! -z \\"$gitCwd\\" ] then
+  $gitCwd=\\"$PWD/$gitCwd\\"
+  debug \\"Updating PWD: $gitCwd\\"
+fi
+
 if [ -f \\"$scriptPath\\" ]; then
   # if [ -t 1 ]; then
   #   exec < /dev/tty
@@ -35,7 +45,7 @@ if [ -f \\"$scriptPath\\" ]; then
     debug \\"source ~/.huskyrc\\"
     . ~/.huskyrc
   fi
-  node_modules/run-node/run-node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+  node_modules/run-node/run-node \\"$scriptPath\\" $hookName \\"$gitParams\\" \\"$gitCwd\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"
   echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
@@ -66,6 +76,16 @@ debug() {
 
 debug \\"$hookName hook started...\\"
 
+
+# Git hooks change the PWD to be the dir where the .git folder lives. GIT_PREFIX
+# stores the original location of where the hook was executed from. This allows
+# us to work out the original PWD.
+gitCwd=\\"$GIT_PREFIX\\"
+if [ ! -z \\"$gitCwd\\" ] then
+  $gitCwd=\\"$PWD/$gitCwd\\"
+  debug \\"Updating PWD: $gitCwd\\"
+fi
+
 if [ -f \\"$scriptPath\\" ]; then
   # if [ -t 1 ]; then
   #   exec < /dev/tty
@@ -74,7 +94,7 @@ if [ -f \\"$scriptPath\\" ]; then
     debug \\"source ~/.huskyrc\\"
     . ~/.huskyrc
   fi
-  node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+  node \\"$scriptPath\\" $hookName \\"$gitParams\\" \\"$gitCwd\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"
   echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -32,9 +32,9 @@ fi
 # stores the original location of where the hook was executed from. This allows
 # us to work out the original PWD.
 gitCwd=\\"$GIT_PREFIX\\"
-if [ ! -z \\"$gitCwd\\" ] then
-  $gitCwd=\\"$PWD/$gitCwd\\"
-  debug \\"Updating PWD: $gitCwd\\"
+if [ ! -z \\"$gitCwd\\" ]; then
+  gitCwd=\\"$(pwd)/$gitCwd\\"
+  debug \\"Updating pwd: $gitCwd\\"
 fi
 
 if [ -f \\"$scriptPath\\" ]; then
@@ -81,9 +81,9 @@ debug \\"$hookName hook started...\\"
 # stores the original location of where the hook was executed from. This allows
 # us to work out the original PWD.
 gitCwd=\\"$GIT_PREFIX\\"
-if [ ! -z \\"$gitCwd\\" ] then
-  $gitCwd=\\"$PWD/$gitCwd\\"
-  debug \\"Updating PWD: $gitCwd\\"
+if [ ! -z \\"$gitCwd\\" ]; then
+  gitCwd=\\"$(pwd)/$gitCwd\\"
+  debug \\"Updating pwd: $gitCwd\\"
 fi
 
 if [ -f \\"$scriptPath\\" ]; then

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -65,9 +65,9 @@ fi
 # stores the original location of where the hook was executed from. This allows
 # us to work out the original PWD.
 gitCwd="$GIT_PREFIX"
-if [ ! -z "$gitCwd" ] then
-  $gitCwd="$PWD/$gitCwd"
-  debug "Updating PWD: $gitCwd"
+if [ ! -z "$gitCwd" ]; then
+  gitCwd="$(pwd)/$gitCwd"
+  debug "Updating pwd: $gitCwd"
 fi
 
 if [ -f "$scriptPath" ]; then

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -60,6 +60,16 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 `
 }
+
+# Git hooks change the PWD to be the dir where the .git folder lives. GIT_PREFIX
+# stores the original location of where the hook was executed from. This allows
+# us to work out the original PWD.
+gitCwd="$GIT_PREFIX"
+if [ ! -z "$gitCwd" ] then
+  $gitCwd="$PWD/$gitCwd"
+  debug "Updating PWD: $gitCwd"
+fi
+
 if [ -f "$scriptPath" ]; then
   # if [ -t 1 ]; then
   #   exec < /dev/tty
@@ -68,7 +78,7 @@ if [ -f "$scriptPath" ]; then
     debug "source ${huskyrc}"
     . ${huskyrc}
   fi
-  ${node} "$scriptPath" $hookName "$gitParams"
+  ${node} "$scriptPath" $hookName "$gitParams" "$gitCwd"
 else
   echo "Can't find Husky, skipping $hookName hook"
   echo "You can reinstall it using 'npm install husky --save-dev' or delete this hook"

--- a/src/runner/__tests__/index.ts
+++ b/src/runner/__tests__/index.ts
@@ -213,7 +213,7 @@ describe('run', (): void => {
     )
   })
 
-  it("should use the root package.json for hooks", async (): Promise<void> => {
+  it('should use the root package.json for hooks', async (): Promise<void> => {
     const dir = tempy.directory()
 
     fs.writeFileSync(
@@ -247,7 +247,7 @@ describe('run', (): void => {
     expect(status).toBe(0)
   })
 
-  it("should use the child package.json for hooks", async (): Promise<void> => {
+  it('should use the child package.json for hooks', async (): Promise<void> => {
     const dir = tempy.directory()
     const childDir = path.join(dir, 'child')
 
@@ -273,7 +273,13 @@ describe('run', (): void => {
       })
     )
 
-    const status = await index(['', getScriptPath(dir), 'pre-commit', '', childDir])
+    const status = await index([
+      '',
+      getScriptPath(dir),
+      'pre-commit',
+      '',
+      childDir
+    ])
     expect(execa.shellSync).toHaveBeenCalledWith('echo child package', {
       cwd: childDir,
       env: {},
@@ -282,7 +288,9 @@ describe('run', (): void => {
     expect(status).toBe(0)
   })
 
-  it("should use the root package.json for hooks when no child package.json", async (): Promise<void> => {
+  it('should use the root package.json for hooks when no child package.json', async (): Promise<
+    void
+  > => {
     const dir = tempy.directory()
     const childDir = path.join(dir, 'child')
 
@@ -298,7 +306,13 @@ describe('run', (): void => {
     )
     fs.mkdirSync(childDir)
 
-    const status = await index(['', getScriptPath(dir), 'pre-commit', '', childDir])
+    const status = await index([
+      '',
+      getScriptPath(dir),
+      'pre-commit',
+      '',
+      childDir
+    ])
     expect(execa.shellSync).toHaveBeenCalledWith('echo root package', {
       cwd: childDir,
       env: {},

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -14,10 +14,17 @@ export interface Env extends NodeJS.ProcessEnv {
  * @param {promise} getStdinFn - used for mocking only
  */
 export default async function run(
-  [, scriptPath, hookName = '', HUSKY_GIT_PARAMS]: string[],
+  [, scriptPath, hookName = '', HUSKY_GIT_PARAMS, HUSKY_GIT_CWD = '']: string[],
   getStdinFn: () => Promise<string> = getStdin
 ): Promise<number> {
-  const cwd = path.resolve(scriptPath.split('node_modules')[0])
+
+  let cwd
+  if (HUSKY_GIT_CWD) {
+    cwd = path.resolve(HUSKY_GIT_CWD)
+  } else {
+    cwd = path.resolve(scriptPath.split('node_modules')[0])
+  }
+
   // In some cases, package.json may not exist
   // For example, when switching to gh-page branch
   let pkg

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -17,7 +17,6 @@ export default async function run(
   [, scriptPath, hookName = '', HUSKY_GIT_PARAMS, HUSKY_GIT_CWD = '']: string[],
   getStdinFn: () => Promise<string> = getStdin
 ): Promise<number> {
-
   let cwd
   if (HUSKY_GIT_CWD) {
     cwd = path.resolve(HUSKY_GIT_CWD)


### PR DESCRIPTION
## Description

The team I work with is currently having issues with Husky in a monorepo like structure. We have a parent project with a set of Husky definitions in its package.json. We also have a child related package in another folder with its own dependencies and scripts in the same repo. We would like to have different set of Husky hooks for the child package.

## Changes

Instead of Husky using the directory of where the .git is located, this will take into account the cwd of the user where they triggered the git hook from. It will then look for the closest package.json from that point.

## A bit more detail

When a git hook runs, it changes the working directory:

> Before Git invokes a hook, it changes its working directory to either $GIT_DIR in a bare repository or the root of the working tree in a non-bare repository. An exception are hooks triggered during a push (pre-receive, update, post-receive, post-update, push-to-checkout) which are always executed in $GIT_DIR
> https://git-scm.com/docs/githooks

To help identify the location of the user, $GIT_PREFIX is set specifying the original path relative to .git (https://github.com/git/git/blob/6f9504c48ea59951a2aa3ee17e7c7fc36285e225/Documentation/config.txt#L762-L763). We can use this information to work out which package.json we want to be reading the config from.

## Outstanding questions/concerns
1. This is quite a big behaviour change.
2. If it finds a child package.json that contains no husky config, should it continue moving up the folder tree till it finds a package.json with a husky config? Obviously stopping at the .git folder level.
3. I have not had a chance to test this on Windows and wondered if you have a preferred method for testing?