### PR TITLE
add yarn pnp support

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -35,6 +35,7 @@ if [ -f \\"$scriptPath\\" ]; then
     debug \\"source ~/.huskyrc\\"
     . ~/.huskyrc
   fi
+  
   node_modules/run-node/run-node \\"$scriptPath\\" $hookName \\"$gitParams\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"
@@ -74,6 +75,7 @@ if [ -f \\"$scriptPath\\" ]; then
     debug \\"source ~/.huskyrc\\"
     . ~/.huskyrc
   fi
+  
   node \\"$scriptPath\\" $hookName \\"$gitParams\\"
 else
   echo \\"Can't find Husky, skipping $hookName hook\\"

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -7,6 +7,7 @@ interface Context {
   createdAt: string
   homepage: string
   node: string
+  nodeOptions: string
   pkgDirectory?: string
   pkgHomepage?: string
   platform: string
@@ -20,11 +21,21 @@ export const huskyIdentifier = '# husky'
 // Experimental
 const huskyrc = '~/.huskyrc'
 
+const getYarnPnpPath = (): string => {
+  try {
+    return require.resolve('pnpapi')
+  } catch (error) {
+    console.log(error)
+    return ''
+  }
+}
+
 // Render script
 const render = ({
   createdAt,
   homepage,
   node,
+  nodeOptions,
   pkgDirectory,
   pkgHomepage,
   platform,
@@ -68,6 +79,7 @@ if [ -f "$scriptPath" ]; then
     debug "source ${huskyrc}"
     . ${huskyrc}
   fi
+  ${nodeOptions ? `export NODE_OPTIONS='${nodeOptions} $NODE_OPTIONS'` : ''}
   ${node} "$scriptPath" $hookName "$gitParams"
 else
   echo "Can't find Husky, skipping $hookName hook"
@@ -111,11 +123,16 @@ export default function(
   // Created at
   const createdAt = new Date().toLocaleString()
 
+  // Create Node Options
+  const yarnPnpPath = getYarnPnpPath()
+  const nodeOptions = yarnPnpPath ? `--require ${yarnPnpPath}` : ''
+
   // Render script
   return render({
     createdAt,
     homepage,
     node,
+    nodeOptions,
     pkgDirectory,
     pkgHomepage,
     platform,


### PR DESCRIPTION
I am using yarns new [PnP](https://yarnpkg.com/en/docs/pnp) node resolution. Unfortunately husky does not work with PnP because it starts node without pnp resolution. This PR is a simple way on install to detect that pnp is enabled by requiring pnpapi. If it exists add the --require to the pnp file as NODE_OPTIONS to be picked up by node.