### PR TITLE
Support searchParentDirs property ("root" property)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -42,6 +42,9 @@ If you have a multi-package repository, it's __recommended__ to use tools like [
 
 Generally speaking, you should AVOID defining `husky` in multiple `package.json`, as each package would overwrite previous `husky` installations.
 
+Alternatively, you can disable this functionality by setting the `searchParentDirs` to `false`, which will cause `husky` to only for `.git` in the directory that the installing `package.json` is in,
+rather then searching each upwards, through each successive parent directory.
+
 ```sh
 .
 └── root

--- a/src/__tests__/getConf.ts
+++ b/src/__tests__/getConf.ts
@@ -13,7 +13,11 @@ describe('getConf', (): void => {
       JSON.stringify(testConf)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      searchParentDirs: true,
+      foo: 'bar'
+    })
   })
 
   it('should allow overriding default conf', (): void => {
@@ -23,7 +27,11 @@ describe('getConf', (): void => {
       JSON.stringify(testConf)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      searchParentDirs: true,
+      foo: 'bar'
+    })
   })
 
   it('should support .huskyrc', (): void => {
@@ -33,6 +41,10 @@ describe('getConf', (): void => {
       JSON.stringify(testConf.husky)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      searchParentDirs: true,
+      foo: 'bar'
+    })
   })
 })

--- a/src/getConf.ts
+++ b/src/getConf.ts
@@ -2,6 +2,7 @@ import cosmiconfig from 'cosmiconfig'
 
 interface Conf {
   skipCI: boolean
+  searchParentDirs: boolean
   hooks?: { [key: string]: string }
 }
 
@@ -10,7 +11,8 @@ export default function getConf(dir: string): Conf {
   const { config = {} } = explorer.searchSync(dir) || {}
 
   const defaults: Conf = {
-    skipCI: true
+    skipCI: true,
+    searchParentDirs: true
   }
 
   return { ...defaults, ...config }

--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -318,6 +318,37 @@ describe('install', (): void => {
     expect(exists('.git/hooks/pre-commit')).toBeFalsy()
   })
 
+  it('should not install hooks if searchParentDirs is false & cwd is git-less', (): void => {
+    mkdir('.git/hooks')
+    mkdir('A/B/node_modules/husky')
+    writeFile(
+      'A/B/package.json',
+      JSON.stringify({ husky: { searchParentDirs: false } })
+    )
+
+    installFrom('A/B/node_modules/husky', 'A/B/node_modules/run-node/run-node')
+
+    expect(exists('.git/hooks/pre-commit')).toBeFalsy()
+  })
+
+  it('should install hooks if searchParentDirs is false & cwd is a git directory', (): void => {
+    const huskyDir = 'node_modules/husky'
+    const hookFilename = '.git/hooks/pre-commit'
+
+    mkdir('.git/hooks')
+    mkdir(huskyDir)
+    writeFile(
+      'package.json',
+      JSON.stringify({ husky: { searchParentDirs: false } })
+    )
+
+    installFrom(huskyDir)
+    expectHookToExist(hookFilename)
+
+    uninstallFrom(huskyDir)
+    expect(exists(hookFilename)).toBeFalsy()
+  })
+
   it('should install in CI server if skipCI is set to false', (): void => {
     mkdir('.git/hooks')
     mkdir('node_modules/husky')

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -168,7 +168,7 @@ export function install(
       "or run 'git init' to create an empty Git repository and reinstall husky."
     )
 
-    if (conf.searchParentDirs) {
+    if (!conf.searchParentDirs) {
       console.log(
         "Note that 'searchParentDirs' is false, so husky won't search parent directories successive for .git"
       )


### PR DESCRIPTION
This closes #502 and should generally make life easier for people wanting to install husky multiple times in the same repo.

Originally, I proposed `root` as it's based off the same property in [`eslint`s config](https://eslint.org/docs/user-guide/configuring#using-configuration-files-1).

However, after discovering that `husky` only supports configs in the same directory as the installing `package.json` I felt `searchParentDirs` was a better fit.

It's `true` by default.