### PR TITLE
Adds an optional settings to use Yarn to run Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "description": "Prevents bad commit or push (git hooks, pre-commit/precommit, pre-push/prepush, post-merge/postmerge and all that stuff...)",
   "bin": {
+    "husky-run": "./run.js",
     "husky-upgrade": "./lib/upgrader/bin.js"
   },
   "engines": {

--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -30,23 +30,28 @@ if [ \\"\${HUSKY_SKIP_HOOKS}\\" = \\"true\\" ] || [ \\"\${HUSKY_SKIP_HOOKS}\\" =
   exit 0
 fi
 
-
-if ! command -v node >/dev/null 2>&1; then
-  echo \\"Info: can't find node in PATH, trying to find a node binary on your system\\"
-fi
-
-if [ -f \\"$scriptPath\\" ]; then
-  # if [ -t 1 ]; then
-  #   exec < /dev/tty
-  # fi
-  if [ -f ~/.huskyrc ]; then
-    debug \\"source ~/.huskyrc\\"
-    . ~/.huskyrc
-  fi
-  node_modules/run-node/run-node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+if [ \\"\${HUSKY_USE_YARN}\\" = \\"true\\" ] || [ \\"\${HUSKY_USE_YARN}\\" = \\"1\\" ]; then
+  debug \\"calling husky through Yarn\\"
+  yarn husky-run $hookName \\"$gitParams\\"
 else
-  echo \\"Can't find Husky, skipping $hookName hook\\"
-  echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
+  
+  if ! command -v node >/dev/null 2>&1; then
+    echo \\"Info: can't find node in PATH, trying to find a node binary on your system\\"
+  fi
+  
+  if [ -f \\"$scriptPath\\" ]; then
+    # if [ -t 1 ]; then
+    #   exec < /dev/tty
+    # fi
+    if [ -f ~/.huskyrc ]; then
+      debug \\"source ~/.huskyrc\\"
+      . ~/.huskyrc
+    fi
+    node_modules/run-node/run-node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+  else
+    echo \\"Can't find Husky, skipping $hookName hook\\"
+    echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
+  fi
 fi
 "
 `;
@@ -81,19 +86,24 @@ if [ \\"\${HUSKY_SKIP_HOOKS}\\" = \\"true\\" ] || [ \\"\${HUSKY_SKIP_HOOKS}\\" =
   exit 0
 fi
 
-
-if [ -f \\"$scriptPath\\" ]; then
-  # if [ -t 1 ]; then
-  #   exec < /dev/tty
-  # fi
-  if [ -f ~/.huskyrc ]; then
-    debug \\"source ~/.huskyrc\\"
-    . ~/.huskyrc
-  fi
-  node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+if [ \\"\${HUSKY_USE_YARN}\\" = \\"true\\" ] || [ \\"\${HUSKY_USE_YARN}\\" = \\"1\\" ]; then
+  debug \\"calling husky through Yarn\\"
+  yarn husky-run $hookName \\"$gitParams\\"
 else
-  echo \\"Can't find Husky, skipping $hookName hook\\"
-  echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
+  
+  if [ -f \\"$scriptPath\\" ]; then
+    # if [ -t 1 ]; then
+    #   exec < /dev/tty
+    # fi
+    if [ -f ~/.huskyrc ]; then
+      debug \\"source ~/.huskyrc\\"
+      . ~/.huskyrc
+    fi
+    node \\"$scriptPath\\" $hookName \\"$gitParams\\"
+  else
+    echo \\"Can't find Husky, skipping $hookName hook\\"
+    echo \\"You can reinstall it using 'npm install husky --save-dev' or delete this hook\\"
+  fi
 fi
 "
 `;

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -59,27 +59,32 @@ if [ "$\{HUSKY_SKIP_HOOKS}" = "true" ] || [ "$\{HUSKY_SKIP_HOOKS}" = "1" ]; then
   exit 0
 fi
 
-${
-  platform === 'win32'
-    ? ''
-    : `
-if ! command -v node >/dev/null 2>&1; then
-  echo "Info: can't find node in PATH, trying to find a node binary on your system"
-fi
-`
-}
-if [ -f "$scriptPath" ]; then
-  # if [ -t 1 ]; then
-  #   exec < /dev/tty
-  # fi
-  if [ -f ${huskyrc} ]; then
-    debug "source ${huskyrc}"
-    . ${huskyrc}
-  fi
-  ${node} "$scriptPath" $hookName "$gitParams"
+if [ "$\{HUSKY_USE_YARN}" = "true" ] || [ "$\{HUSKY_USE_YARN}" = "1" ]; then
+  debug "calling husky through Yarn"
+  yarn husky-run $hookName "$gitParams"
 else
-  echo "Can't find Husky, skipping $hookName hook"
-  echo "You can reinstall it using 'npm install husky --save-dev' or delete this hook"
+  ${
+    platform === 'win32'
+      ? ''
+      : `
+  if ! command -v node >/dev/null 2>&1; then
+    echo "Info: can't find node in PATH, trying to find a node binary on your system"
+  fi
+  `
+  }
+  if [ -f "$scriptPath" ]; then
+    # if [ -t 1 ]; then
+    #   exec < /dev/tty
+    # fi
+    if [ -f ${huskyrc} ]; then
+      debug "source ${huskyrc}"
+      . ${huskyrc}
+    fi
+    ${node} "$scriptPath" $hookName "$gitParams"
+  else
+    echo "Can't find Husky, skipping $hookName hook"
+    echo "You can reinstall it using 'npm install husky --save-dev' or delete this hook"
+  fi
 fi
 `
 


### PR DESCRIPTION
This fix has multiple purposes that improve the compatibility with Yarn at little cost:

- First, it ensures that the Husky command will run with the same pipeline as the one used by Husky's users when they run their scripts. It previously wasn't the case, because Husky was using `run-node` to "detect" the version of Node to use whereas Yarn users were using `yarn run [...]` (which enforces the Node version to be the same one as the one used to run Yarn itself).

- Second, starting from Yarn 2 we're looking to keep packages inside their tarballs as much as possible. In the context of `run-node` this causes problems, because `run-node` is a shellscript and can only be executed when unpacked. Using `yarn husky-run` avoids the issue altogether.

- Third, when working with PnP environments, if we call the Node script manually, then we need to inject the PnP hook so that Husky knows how to load its dependencies (since they aren't in the `node_modules` folder anymore). Using `yarn run` makes this process transparent: it will inject the hook when running under PnP, and won't do it otherwise, and the Husky script won't have to know anything about it.

- Four, I'd like to make it possible to track which scripts and binary are used in an application (through Yarn's new plugin system). Directly calling the Husky script wouldn't allow that, but going through `yarn run` would.

I guess later we can see whether it would make sense to enable `HUSKY_USE_YARN` by default in some circumstances, but for now I think it's fine if we keep it behind a variable that must be set through a repository-local rcfile (cf #510).
