### PR TITLE
Fix HUSKY_SKIP_INSTALL=1 not skipping install

### DIFF
--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -303,6 +303,15 @@ describe('install', (): void => {
     expect(hook).toMatch(huskyIdentifier)
   })
 
+  it('should not install hooks if HUSKY_SKIP_INSTALL=1', (): void => {
+    mkdir(defaultGitDir, defaultHuskyDir)
+    writeFile('package.json', pkg)
+
+    process.env.HUSKY_SKIP_INSTALL = '1'
+    install()
+    expect(exists(defaultHookFilename)).toBeFalsy()
+  })
+
   it('should not install hooks if HUSKY_SKIP_INSTALL=true', (): void => {
     mkdir(defaultGitDir, defaultHuskyDir)
     writeFile('package.json', pkg)

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -137,7 +137,7 @@ export function install(
   const conf = getConf(userPkgDir)
 
   // Checks
-  if (process.env.HUSKY_SKIP_INSTALL === 'true') {
+  if (['1', 'true'].includes(process.env.HUSKY_SKIP_INSTALL || '')) {
     console.log(
       "HUSKY_SKIP_INSTALL environment variable is set to 'true',",
       'skipping Git hooks installation.'


### PR DESCRIPTION
[Disable auto-install](https://github.com/typicode/husky/blob/8920e331f78ccbfe4f41de753a268cdcba3da2e4/DOCS.md#disable-auto-install) in the documentation suggests to set `HUSKY_SKIP_INSTALL` to `1` to skip automatic installation of Git hooks. However, Husky actually only skipped installation if `HUSKY_SKIP_INSTALL` was set to `true` (instead of `1`).

I’ve changed the condition to test for both `1` and `true` (similar to how it’s already done in [`debug.ts`](https://github.com/typicode/husky/blob/8920e331f78ccbfe4f41de753a268cdcba3da2e4/src/debug.ts#L2)) and added a test.