### PR TITLE
Support root property

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -71,6 +71,38 @@ Generally speaking, you should AVOID defining `husky` in multiple `package.json`
 }
 ```
 
+Alternatively, you can use the `root` property to tell `husky` to only install if the [git `toplevel`](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-toplevel) directory is the same as the one with the installing `package.json`:
+
+```sh
+.
+└── root 🐶 # git toplevel points here
+    ├── .git
+    ├── package.json # husky will be installed as a depenceny *and* hooks will be installed
+    └── packages
+        ├── A
+        │   └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        ├── B
+        │   └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        └── C
+            └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+```
+
+```js
+// any package.json
+{
+  "private": true,
+  "devDependencies": {
+    "husky": "..."
+  },
+  "husky": {
+    "root": true,
+    "hooks": {
+      "pre-commit": "..."
+    }
+  }
+}
+```
+
 ## Node version management
 
 If you're on Windows, husky will simply use the version installed globally on your system.

--- a/DOCS.md
+++ b/DOCS.md
@@ -80,11 +80,11 @@ Alternatively, you can use the `root` property to tell `husky` to only install i
     ├── package.json 🐶 # husky will be installed as a depenceny *and* hooks will be installed
     └── packages
         ├── A
-        │   └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
         ├── B
-        │   └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
         └── C
-            └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
+            └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
 ```
 
 ```js

--- a/DOCS.md
+++ b/DOCS.md
@@ -75,16 +75,16 @@ Alternatively, you can use the `root` property to tell `husky` to only install i
 
 ```sh
 .
-└── root 🐶 # git toplevel points here
+└── root # git toplevel points here
     ├── .git
-    ├── package.json # husky will be installed as a depenceny *and* hooks will be installed
+    ├── package.json 🐶 # husky will be installed as a depenceny *and* hooks will be installed
     └── packages
         ├── A
-        │   └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
         ├── B
-        │   └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
         └── C
-            └── package.json # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+            └── package.json # 🐕 husky will be installed as a depenceny *only* (i.e hooks will not installed)
 ```
 
 ```js

--- a/DOCS.md
+++ b/DOCS.md
@@ -77,14 +77,14 @@ Alternatively, you can use the `root` property to tell `husky` to only install i
 .
 └── root # git toplevel points here
     ├── .git
-    ├── package.json 🐶 # husky will be installed as a depenceny *and* hooks will be installed
+    ├── package.json 🐶 # husky will be installed as a dependency *and* hooks will be installed
     └── packages
         ├── A
-        │   └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json 🐕 # husky will be installed as a dependency *only* (i.e hooks will not installed)
         ├── B
-        │   └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+        │   └── package.json 🐕 # husky will be installed as a dependency *only* (i.e hooks will not installed)
         └── C
-            └── package.json 🐕 # husky will be installed as a depenceny *only* (i.e hooks will not installed)
+            └── package.json 🐕 # husky will be installed as a dependency *only* (i.e hooks will not installed)
 ```
 
 ```js

--- a/src/getConf.ts
+++ b/src/getConf.ts
@@ -2,6 +2,7 @@ import cosmiconfig from 'cosmiconfig'
 
 interface Conf {
   skipCI: boolean
+  root?: boolean
   hooks?: { [key: string]: string }
 }
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -145,6 +145,13 @@ export function install(
     return
   }
 
+  if (conf.root && !userPkgDir.endsWith(path.join(topLevel))) {
+    console.log(
+      "Can't find .git in root directory, skipping Git hooks installation."
+    )
+    return
+  }
+
   if (isCI && conf.skipCI) {
     console.log('CI detected, skipping Git hooks installation.')
     return


### PR DESCRIPTION
This closes #502 and should generally make life easier for people wanting to install husky multiple times in the same repo.

Superseeds #504

It's based off the `root` property in [`eslint`s config](https://eslint.org/docs/user-guide/configuring#using-configuration-files-1).

It's `false` by default, and should work w/ git-submodules, but I don't know about working trees as I've not used either.