### PR TITLE
Add shebang to run.js

### DIFF
--- a/run.js
+++ b/run.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires */
 const pleaseUpgradeNode = require('please-upgrade-node')
 const pkg = require('./package.json')


### PR DESCRIPTION
Having just upgraded from 2.4.1, I've found that the hooks fail with Yarn support enabled:

```
$ HUSKY_DEBUG=1 git commit
husky:debug pre-commit hook started
husky:debug calling husky through Yarn
yarn run v1.17.0
$ […]/node_modules/.bin/husky-run pre-commit ''
[…]/node_modules/.bin/husky-run: 1: […]/node_modules/.bin/husky-run: /bin: Permission denied
[…]/node_modules/.bin/husky-run: 2: […]/node_modules/.bin/husky-run: Syntax error: "(" unexpected
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Looks like Yarn is trying to exec husky-run directly, while the npm codepath just runs it as a Node script. Adding a shebang fixes the issue.
