### PR TITLE
Optionally overwrite existing hooks

### DIFF
--- a/src/__tests__/getConf.ts
+++ b/src/__tests__/getConf.ts
@@ -13,7 +13,11 @@ describe('getConf', (): void => {
       JSON.stringify(testConf)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      foo: 'bar',
+      overwriteExisting: false
+    })
   })
 
   it('should allow overriding default conf', (): void => {
@@ -23,7 +27,11 @@ describe('getConf', (): void => {
       JSON.stringify(testConf)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      foo: 'bar',
+      overwriteExisting: false
+    })
   })
 
   it('should support .huskyrc', (): void => {
@@ -33,6 +41,10 @@ describe('getConf', (): void => {
       JSON.stringify(testConf.husky)
     )
 
-    expect(getConf(tempDir)).toEqual({ skipCI: true, foo: 'bar' })
+    expect(getConf(tempDir)).toEqual({
+      skipCI: true,
+      foo: 'bar',
+      overwriteExisting: false
+    })
   })
 })

--- a/src/getConf.ts
+++ b/src/getConf.ts
@@ -2,6 +2,7 @@ import cosmiconfig from 'cosmiconfig'
 
 interface Conf {
   skipCI: boolean
+  overwriteExisting: boolean
   hooks?: { [key: string]: string }
 }
 
@@ -10,7 +11,8 @@ export default function getConf(dir: string): Conf {
   const { config = {} } = explorer.searchSync(dir) || {}
 
   const defaults: Conf = {
-    skipCI: true
+    skipCI: true,
+    overwriteExisting: false
   }
 
   return { ...defaults, ...config }

--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -141,7 +141,7 @@ describe('install', (): void => {
     expect(hook).not.toContain('foo')
   })
 
-  it('should not modify user hooks', (): void => {
+  it('should, by default, not modify user hooks', (): void => {
     mkdir(defaultGitHooksDir, defaultHuskyDir)
     writeFile('package.json', pkg)
     writeFile(defaultHookFilename, 'foo')
@@ -154,6 +154,24 @@ describe('install', (): void => {
     // Verify that it's not deleted
     uninstall()
     expect(exists(defaultHookFilename)).toBeTruthy()
+  })
+
+  it('should modify user hooks when overwriteExisting is true', (): void => {
+    mkdir(defaultGitHooksDir, defaultHuskyDir)
+    writeFile(
+      'package.json',
+      JSON.stringify({ husky: { overwriteExisting: true } })
+    )
+    writeFile(defaultHookFilename, 'foo')
+
+    // Verify that it's overwritten
+    install()
+    const hook = readFile(defaultHookFilename)
+    expect(hook).toMatch('node_modules/husky/run.js')
+
+    // Verify that it's deleted
+    uninstall()
+    expect(exists(defaultHookFilename)).toBeFalsy()
   })
 
   it('should support package.json installed in sub directory', (): void => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -32,13 +32,23 @@ function writeHook(filename: string, script: string): void {
   fs.chmodSync(filename, 0o0755)
 }
 
-function createHook(filename: string, script: string): void {
+function createHook(
+  filename: string,
+  script: string,
+  overwriteExisting: boolean
+): void {
   // Get name, used for logging
   const name = path.basename(filename)
 
   // Check if hook exist
   if (fs.existsSync(filename)) {
     const hook = fs.readFileSync(filename, 'utf-8')
+
+    // Overwrite
+    if (overwriteExisting) {
+      console.log(`overwriting existing ghooks script: ${name}`)
+      return writeHook(filename, script)
+    }
 
     // Migrate
     if (isGhooks(hook)) {
@@ -66,8 +76,14 @@ function createHook(filename: string, script: string): void {
   writeHook(filename, script)
 }
 
-function createHooks(filenames: string[], script: string): void {
-  filenames.forEach((filename: string): void => createHook(filename, script))
+function createHooks(
+  filenames: string[],
+  script: string,
+  overwriteExisting: boolean
+): void {
+  filenames.forEach((filename: string): void =>
+    createHook(filename, script, overwriteExisting)
+  )
 }
 
 function canRemove(filename: string): boolean {
@@ -169,7 +185,7 @@ export function install(
 
   const hooks = getHooks(gitDir)
   const script = getScript(topLevel, huskyDir, requireRunNodePath)
-  createHooks(hooks, script)
+  createHooks(hooks, script, conf.overwriteExisting)
 
   console.log(`husky > Done`)
 }


### PR DESCRIPTION
# Problem

I'm working within an organization where we get Git Bash pre packaged with hooks. We cannot change that and every developer will get these hooks, from the installation of Git Bash, installed when cloning repositories. The pre packaged hooks will make Husky ignore any hooks configured in `package.json`.

Developers must do something like:
```shell
git clone whatever.git
rm ./git/hooks/*
npm install
```

# Solution

Adding a configuration option (`overwriteExisting`) to `package.json` like:
```json
...
"skipCI": true,
"overwriteExisting": true
"pre-commit": ...
``` 

With `overwriteExisting` as `true` in the configuration it will overwrite any existing hook on `npm install`.

Fixes #336 and #558