### PR TITLE
Add HUSKY_SKIP_UNINSTALL option

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -28,6 +28,12 @@ If you don't want `husky` to automatically install Git hooks, simply set `HUSKY_
 HUSKY_SKIP_INSTALL=1 npm install
 ```
 
+Likewise, if you don't want `husky` to automatically uninstall the hooks it has previously installed, set `HUSKY_SKIP_UNINSTALL` environment variable to `1`.
+
+```sh
+HUSKY_SKIP_UNINSTALL=1 npm install
+```
+
 ## Skip all hooks
 
 During a rebase you may want to skip all hooks, you can set `HUSKY_SKIP_HOOKS` environment variable to `1`.

--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -303,7 +303,29 @@ describe('install', (): void => {
     expect(hook).toMatch(huskyIdentifier)
   })
 
-  it('should not install hooks if HUSKY_SKIP_INSTALL=1', (): void => {
+  it('should not install hooks if HUSKY_SKIP_UNINSTALL=1', (): void => {
+    mkdir(defaultGitDir, defaultHuskyDir)
+    writeFile('package.json', pkg)
+
+    process.env.HUSKY_SKIP_UNINSTALL = '1'
+    install()
+    expect(exists(defaultHookFilename)).toBeTruthy()
+    uninstall()
+    expect(exists(defaultHookFilename)).toBeTruthy()
+  })
+
+  it('should not install hooks if HUSKY_SKIP_UNINSTALL=true', (): void => {
+    mkdir(defaultGitDir, defaultHuskyDir)
+    writeFile('package.json', pkg)
+
+    process.env.HUSKY_SKIP_UNINSTALL = 'true'
+    install()
+    expect(exists(defaultHookFilename)).toBeTruthy()
+    uninstall()
+    expect(exists(defaultHookFilename)).toBeTruthy()
+  })
+
+  it('should not uninstall hooks if HUSKY_SKIP_INSTALL=1', (): void => {
     mkdir(defaultGitDir, defaultHuskyDir)
     writeFile('package.json', pkg)
 
@@ -312,7 +334,7 @@ describe('install', (): void => {
     expect(exists(defaultHookFilename)).toBeFalsy()
   })
 
-  it('should not install hooks if HUSKY_SKIP_INSTALL=true', (): void => {
+  it('should not uninstall hooks if HUSKY_SKIP_INSTALL=true', (): void => {
     mkdir(defaultGitDir, defaultHuskyDir)
     writeFile('package.json', pkg)
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -171,6 +171,14 @@ export function install(
 }
 
 export function uninstall(gitDir: string, huskyDir: string): void {
+  if (['1', 'true'].includes(process.env.HUSKY_SKIP_UNINSTALL || '')) {
+    console.log(
+      "HUSKY_SKIP_UNINSTALL environment variable is set to 'true',",
+      'skipping Git hooks uninstallation.'
+    )
+    return
+  }
+
   if (gitDir === null) {
     console.log(
       "Can't find resolved .git directory, skipping Git hooks uninstallation."


### PR DESCRIPTION
I think it would be useful to have the option to not uninstall git hooks when husky is uninstalled.

For my use case, I need to check in my node_modules, but I don't want to check in dev-dependencies. So during my post-commit stage, I'm running something like:

`npm prune --production && git add node_modules/* && git commit -m \"Husky commit correct node modules\" && npm install`

In general, this works great - the correct node_modules get committed - however, when I run npm install Husky tries and fails to add its hooks since the hook file its trying to write to is already open. So I lose my hooks in the process. What I'd really like to do is

`export HUSKY_SKIP_UNINSTALL=1 && export HUSKY_SKIP_INSTALL=1 && npm prune --production && git add node_modules/* && git commit -m \"Husky commit correct node modules\" && npm install`