### PR TITLE
Fixes "yarn run"

### DIFF
--- a/src/installer/__tests__/__snapshots__/getScript.ts.snap
+++ b/src/installer/__tests__/__snapshots__/getScript.ts.snap
@@ -26,10 +26,10 @@ command_exists () {
 
 run_command () {
   if command_exists \\"$1\\"; then
-    \\"$1\\" \\"$2\\" husky-run $hookName \\"$gitParams\\"
+    \\"$@\\" husky-run $hookName \\"$gitParams\\"
 
     exitCode=\\"$?\\"
-    debug \\"$1 $2 husky-run exited with $exitCode exit code\\"
+    debug \\"$* husky-run exited with $exitCode exit code\\"
 
     if [ $exitCode -eq 127 ]; then
       echo \\"Can't find Husky, skipping $hookName hook\\"

--- a/src/installer/getScript.ts
+++ b/src/installer/getScript.ts
@@ -51,10 +51,10 @@ command_exists () {
 
 run_command () {
   if command_exists "$1"; then
-    "$1" "$2" husky-run $hookName "$gitParams"
+    "$@" husky-run $hookName "$gitParams"
 
     exitCode="$?"
-    debug "$1 $2 husky-run exited with $exitCode exit code"
+    debug "$* husky-run exited with $exitCode exit code"
 
     if [ $exitCode -eq 127 ]; then
       echo "Can't find Husky, skipping $hookName hook"


### PR DESCRIPTION
There's a problem in the 4.0.0-0 where the parameters sent to Yarn are as such:

```
yarn "" husky-run pre-commit
```

This empty second argument is caused by explicitly passing `$1 $2` as parameter (Yarn doesn't need a second argument, so Bash is replacing it with an empty string).

This diff fixes that by using `"$@"` instead, which expands to the list of arguments passed to the function (so `"npx" "--no-install"` for npx, and simply `"yarn"` for Yarn).