### PR TITLE
[Fix] Prevent postinstall from failing on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postpublish": "pinst --disable",
     "lint": "eslint . --ext .js,.ts --ignore-path .gitignore",
     "fix": "npm run lint -- --fix",
-    "postinstall": "opencollective-postinstall || true"
+    "postinstall": "opencollective-postinstall || exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes: https://github.com/typicode/husky/issues/565

From that issue:
> On windows, there's no `true`. Looking at other popular packages, I believe `|| exit 0` is a more reliable way to handle this ([1](https://github.com/remy/nodemon/blob/master/package.json), [2](https://github.com/styled-components/styled-components/blob/master/packages/styled-components/package.json))

This change was tested by removing the `opencollective-postinstall` script from the .bin folder, and then running `npm run postinstall` in cmd and powershell. In both shells I validated that without this change, the process exits with a non-zero exit code (cannot find 'opencollective-postinstall', cannot find 'true'), and with this change that it exits with an exit code of zero.