### PR TITLE
Expose husky-installer as an executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.5",
   "description": "Prevents bad commit or push (git hooks, pre-commit/precommit, pre-push/prepush, post-merge/postmerge and all that stuff...)",
   "bin": {
+    "husky-installer": "./husky.js",
     "husky-run": "./run.js",
     "husky-upgrade": "./lib/upgrader/bin.js"
   },


### PR DESCRIPTION
We found ourselves wanting to implement a custom setup where we need to re-run husky's installer if we find the wrong git-hook in place post-install. To do this, we are having to run `./husky.js` directly. We think it would make sense to expose this to users in our situation.