### PR TITLE
Remove is-ci in favor of ci-info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -502,6 +502,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5R2/MHILQLDCzTuhs1j4Qqq8AaKUf7Ma4KSSkCtc12+fMs47zfa34qhto9goxpyX00tQK1zxB885VCiawZ5Qhg=="
+    },
     "@types/cosmiconfig": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz",
@@ -3304,6 +3309,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "homepage": "https://github.com/typicode/husky#readme",
   "dependencies": {
     "chalk": "^2.4.2",
+    "ci-info": "^2.0.0",
     "cosmiconfig": "^5.2.1",
     "execa": "^1.0.0",
     "get-stdin": "^7.0.0",
-    "is-ci": "^2.0.0",
     "opencollective-postinstall": "^2.0.2",
     "pkg-dir": "^4.2.0",
     "please-upgrade-node": "^3.2.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,3 @@
 declare module 'execa'
-declare module 'is-ci'
+declare module 'ci-info'
 declare module 'slash'

--- a/src/installer/bin.ts
+++ b/src/installer/bin.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import isCI from 'is-ci'
+import { isCI } from 'ci-info'
 import path from 'path'
 import debug from '../debug'
 import { install, uninstall } from './'


### PR DESCRIPTION
Instead of having is-ci call ci-info's ci.isCI, we might as well call ci.isCI within the installation directly. This allows us to shorten the dependency branch by 1 step which is a trivial amount of gain, but it nonetheless reduces the length of the package-lock