### PR TITLE
default exitCode is 1; thus breaking scripts

### DIFF
--- a/run.js
+++ b/run.js
@@ -5,6 +5,7 @@ const pkg = require('./package.json')
 
 // Node version isn't supported, skip
 pleaseUpgradeNode(pkg, {
+  exitCode: 0,
   message(requiredVersion) {
     return 'Husky requires Node ' + requiredVersion + ", can't run Git hook."
   }


### PR DESCRIPTION
On a CI server or building in a docker container on CI husky still installs but fails the build as exitCode 1 is present.

My setup is a jenkins server running master/slave configuration. Slaves themselves don't have node and instead I run:

```
#! /usr/bin/env bash

set -e
set -x

environment=$1

docker run \
  -i --rm \
  --user=$(id -u):$(id -g) \
  -v ${WORKSPACE}:${WORKSPACE} \
  -v ${HOME}:${HOME} \
  -v /etc/passwd:/etc/passwd:ro \
  -e npm_config_cache=${WORKSPACE}/.npm \
  -e HOME=${HOME} \
  -e USER=${USER} \
  -w ${WORKSPACE} \
  node:12 \
  sh build.sh $environment
```

This builds and runs tests and outputs coverage info to the host as the directories are mapped.

First build is okay as husky and the node_modules folder never exists however on subsequent builds (until the machine recycles) husky will fail to run as node doesn't exist and the post-checkout hook is run.