### PR TITLE
Add skipDeprecatedHooks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Starting with `1.0.0`, husky can be configured using `.huskyrc`, `.huskyrc.json`
 }
 ```
 
+If you have a `precommit` script defined in `scripts`, it will be treated as a `pre-commit` hook in `husky.hooks` to remain backward compatible with older version of Husky. If you want to disable this behaviour, you can define `skipDeprecatedHooks` in your configuration. This applies to all hooks.
+
+```json
+{
+  "husky": {
+    "hooks": {},
+    "skipDeprecatedHooks": true
+  }
+}
+```
+
 ### Supported hooks
 
 Husky supports all Git hooks defined [here](https://git-scm.com/docs/githooks). Server-side hooks (`pre-receive`, `update` and `post-receive`) aren't supported.

--- a/src/getConf.ts
+++ b/src/getConf.ts
@@ -2,6 +2,7 @@ import cosmiconfig from 'cosmiconfig'
 
 interface Conf {
   skipCI: boolean
+  skipDeprecatedHooks?: boolean
   hooks?: { [key: string]: string }
 }
 

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -37,11 +37,15 @@ export default async function run(
 
   const config = getConf(cwd)
 
+  const skipOldCommand: boolean | undefined =
+    config && config.skipDeprecatedHooks === true
+
   const command: string | undefined =
     config && config.hooks && config.hooks[hookName]
 
-  const oldCommand: string | undefined =
-    pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
+  const oldCommand: string | undefined = skipOldCommand
+    ? undefined
+    : pkg && pkg.scripts && pkg.scripts[hookName.replace('-', '')]
 
   // Run command
   try {
@@ -70,6 +74,10 @@ export default async function run(
       )
       console.log(
         `Or run ./node_modules/.bin/husky-upgrade for automatic update`
+      )
+      console.log()
+      console.log(
+        `Alternatively, disable support for legacy hooks by setting husky.skipDeprecatedHooks to true `
       )
       console.log()
       console.log(`See https://github.com/typicode/husky for usage`)


### PR DESCRIPTION
This option disables the backward compatibility with older versions of Husky,
so that the "scripts" in dictionary can contain hook-like keys without them
being treated as hooks.

Closes: #622