### PR TITLE
Support all documented git hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3588,6 +3588,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "git-hooks-list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.2.tgz",
+      "integrity": "sha512-C3c/FG6Pgh053+yK/CnNNYJo5mgCa3OeI+cPxPIl0tyMLm1mGfiV0NX0LrhnjVoX7dfkR78WyW2kvFVHvAlneg=="
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ci-info": "^2.0.0",
     "cosmiconfig": "^6.0.0",
     "get-stdin": "^7.0.0",
+    "git-hooks-list": "^1.0.2",
     "opencollective-postinstall": "^2.0.2",
     "pkg-dir": "^4.2.0",
     "please-upgrade-node": "^3.2.0",

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1,32 +1,10 @@
 import fs from 'fs'
 import path from 'path'
+import hookList from 'git-hooks-list'
 import { debug } from '../debug'
 import getConf from '../getConf'
 import getScript from './getScript'
 import { isGhooks, isHusky, isPreCommit, isYorkie } from './is'
-
-const hookList = [
-  'applypatch-msg',
-  'pre-applypatch',
-  'post-applypatch',
-  'pre-commit',
-  'pre-merge-commit',
-  'prepare-commit-msg',
-  'commit-msg',
-  'post-commit',
-  'pre-rebase',
-  'post-checkout',
-  'post-merge',
-  'pre-push',
-  'pre-receive',
-  'update',
-  'post-receive',
-  'post-update',
-  'push-to-checkout',
-  'pre-auto-gc',
-  'post-rewrite',
-  'sendemail-validate'
-]
 
 function writeHook(filename: string, script: string): void {
   fs.writeFileSync(filename, script, 'utf-8')

--- a/src/upgrader/index.ts
+++ b/src/upgrader/index.ts
@@ -1,33 +1,19 @@
 import fs from 'fs'
 import path from 'path'
+import gitHooks from 'git-hooks-list'
 import { readPkg } from '../read-pkg'
 
 interface HookMap {
   [key: string]: string
 }
 
-const hookList: HookMap = {
-  applypatchmsg: 'applypatch-msg',
-  commitmsg: 'commit-msg',
-  postapplypatch: 'post-applypatch',
-  postcheckout: 'post-checkout',
-  postcommit: 'post-commit',
-  postmerge: 'post-merge',
-  postreceive: 'post-receive',
-  postrewrite: 'post-rewrite',
-  postupdate: 'post-update',
-  preapplypatch: 'pre-applypatch',
-  preautogc: 'pre-auto-gc',
-  precommit: 'pre-commit',
-  premergecommit: 'pre-merge-commit',
-  preparecommitmsg: 'prepare-commit-msg',
-  prepush: 'pre-push',
-  prerebase: 'pre-rebase',
-  prereceive: 'pre-receive',
-  pushtocheckout: 'push-to-checkout',
-  sendemailvalidate: 'sendemail-validate',
-  update: 'update'
-}
+const hookList: HookMap = gitHooks.reduce(
+  (hookList: HookMap, hook: string): HookMap => {
+    hookList[hook.replace(/-/g, '')] = hook
+    return hookList
+  },
+  {}
+)
 
 export default function upgrade(cwd: string): void {
   const pkgFile = path.join(cwd, 'package.json')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "exclude": ["**/__tests__/*"]
 }


### PR DESCRIPTION
Support all documented git hooks with [`git-hooks-list`](https://www.npmjs.com/package/git-hooks-list) module.

Missing hooks:

- fsmonitor-watchman
- p4-pre-submit
- post-index-change

FYI: this `git-hooks-list` module is build to sort `husky.hooks` field in package.json https://github.com/keithamus/sort-package-json/pull/103