### PR TITLE
fix: use process.exit if install fails

### DIFF
--- a/src/installer/bin.ts
+++ b/src/installer/bin.ts
@@ -103,6 +103,7 @@ function run(): void {
     console.log(chalk.red(err.message.trim()))
     debug(err.stack)
     console.log(chalk.red(`husky > Failed to ${action}`))
+    process.exit(1)
   }
 }
 

--- a/src/installer/bin.ts
+++ b/src/installer/bin.ts
@@ -103,7 +103,7 @@ function run(): void {
     console.log(chalk.red(err.message.trim()))
     debug(err.stack)
     console.log(chalk.red(`husky > Failed to ${action}`))
-    process.exit(1)
+    process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
When using Yarn v2 there is no console output from installs unless they fail, since husky doesn't change the exit code it seems like the install succeeded when it actually failed