### PR TITLE
Revert "fix: use process.exit if install fails"

### DIFF
--- a/src/installer/bin.ts
+++ b/src/installer/bin.ts
@@ -103,7 +103,6 @@ function run(): void {
     console.log(chalk.red(err.message.trim()))
     debug(err.stack)
     console.log(chalk.red(`husky > Failed to ${action}`))
-    process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
Reverts typicode/husky#633 rollbacking for the moment due to #636 