### PR TITLE
fix: husky.config.js not .huskyrc.config.js

### DIFF
--- a/sh/husky.sh
+++ b/sh/husky.sh
@@ -58,7 +58,7 @@ debug "Current working directory is $(pwd)"
 # Don't skip if .huskyrc.js or .huskyrc.config.js are used as the heuristic could
 # fail due to the dynamic aspect of JS. For example:
 # `"pre-" + "commit"` or `require('./config/hooks')`)
-if [ ! -f .huskyrc.js ] && [ ! -f .huskyrc.config.js ] && ! hookIsDefined; then
+if [ ! -f .huskyrc.js ] && [ ! -f husky.config.js ] && ! hookIsDefined; then
   debug "$hookName config not found, skipping hook"
   exit 0
 fi

--- a/src/installer/__tests__/__snapshots__/scripts.ts.snap
+++ b/src/installer/__tests__/__snapshots__/scripts.ts.snap
@@ -87,7 +87,7 @@ debug \\"Current working directory is $(pwd)\\"
 # Don't skip if .huskyrc.js or .huskyrc.config.js are used as the heuristic could
 # fail due to the dynamic aspect of JS. For example:
 # \`\\"pre-\\" + \\"commit\\"\` or \`require('./config/hooks')\`)
-if [ ! -f .huskyrc.js ] && [ ! -f .huskyrc.config.js ] && ! hookIsDefined; then
+if [ ! -f .huskyrc.js ] && [ ! -f husky.config.js ] && ! hookIsDefined; then
   debug \\"$hookName config not found, skipping hook\\"
   exit 0
 fi


### PR DESCRIPTION
in [readme](https://github.com/typicode/husky/blob/master/README.md#upgrading-from-014) it says:

> Starting with 1.0.0, husky can be configured using .huskyrc, .huskyrc.json, .huskyrc.js or husky.config.js file.