### PR TITLE
Add exit code check after calling husky.local.sh

### DIFF
--- a/sh/husky.sh
+++ b/sh/husky.sh
@@ -52,6 +52,13 @@ fi
 
 # Source user var and change directory
 . "$(dirname "$0")/husky.local.sh"
+
+cdExitCode="$?"
+if [ $cdExitCode -ne 0 ]; then
+  debug "Change directory (husky.local.sh) failed with $cdExitCode exit code"
+  exit $cdExitCode
+fi
+
 debug "Current working directory is $(pwd)"
 
 # Skip fast if hookName is not defined

--- a/src/installer/__tests__/__snapshots__/scripts.ts.snap
+++ b/src/installer/__tests__/__snapshots__/scripts.ts.snap
@@ -81,6 +81,13 @@ fi
 
 # Source user var and change directory
 . \\"$(dirname \\"$0\\")/husky.local.sh\\"
+
+cdExitCode=\\"$?\\"
+if [ $cdExitCode -ne 0 ]; then
+  debug \\"Change directory (husky.local.sh) failed with $cdExitCode exit code\\"
+  exit $cdExitCode
+fi
+
 debug \\"Current working directory is $(pwd)\\"
 
 # Skip fast if hookName is not defined


### PR DESCRIPTION
We have a git repo with multiple directories for projects, and husky was installed in one of the front-end projects in some path under the root.  For example:

```
[repo]
  |-- [.git]
  |-- [front-end-app]
    	|-- package.json
    	|-- ...
  |-- [non-npm-app1]
  |-- [non-npm-app2]
  |-- ...
```

Then we changed the front-end project's directory name.  A little while after, we noticed that some commits that should've failed were going through.  It seems husky was "silently failing" if the directory name has been changed from the value specified in `husky.local.sh`.  It's probably an edge case, but this fix adds exit code check so that the hook will fail if husky can't change the directory to where it expects it to be.