### PR TITLE
fix: cnpm fails due to $packgeManager not matched

### DIFF
--- a/sh/husky.sh
+++ b/sh/husky.sh
@@ -83,7 +83,8 @@ fi
 # Run husky-run with the package manager used to install Husky
 case $packageManager in
   "npm") run_command npx --no-install;;
+  "npminstall") run_command npx --no-install;;
   "pnpm") run_command pnpx --no-install;;
   "yarn") run_command yarn run --silent;;
-  "*") echo "Unknown package manager: $packageManager"; exit 0;;
+  *) echo "Unknown package manager: $packageManager"; exit 0;;
 esac

--- a/src/installer/__tests__/__snapshots__/scripts.ts.snap
+++ b/src/installer/__tests__/__snapshots__/scripts.ts.snap
@@ -112,9 +112,10 @@ fi
 # Run husky-run with the package manager used to install Husky
 case $packageManager in
   \\"npm\\") run_command npx --no-install;;
+  \\"npminstall\\") run_command npx --no-install;;
   \\"pnpm\\") run_command pnpx --no-install;;
   \\"yarn\\") run_command yarn run --silent;;
-  \\"*\\") echo \\"Unknown package manager: $packageManager\\"; exit 0;;
+  *) echo \\"Unknown package manager: $packageManager\\"; exit 0;;
 esac
 "
 `;


### PR DESCRIPTION
close #682
close #676
close cnpm/cnpm#318

### Reproduce steps

```
npm i cnpm -g
git clone git@github.com:afc163/husky-test.git
cd husky-test
cnpm i
touch README && git add README
git commit -am 'commit message'
```

husky `pre-commit` is not running.

### Reason

`$packageManager` of husky defined didn't contain `cnpm`, which is using https://github.com/cnpm/npminstall, the `$packageManager` value should be `npminstall`.

### Solution

It can be fallback to `npx` when `$packageManager` is `npminstall`.

Additionally, fixed `Unknown package manager` logic according to #682 in which @MondoGao had described.