### PR TITLE
replace postinstall with npm funding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6191,11 +6191,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "opencollective-postinstall": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "postpublish": "pinst --disable",
     "lint": "eslint . --ext .js,.ts --ignore-path .gitignore",
     "fix": "npm run lint -- --fix",
-    "doc": "markdown-toc -i README.md",
-    "_postinstall": "opencollective-postinstall || exit 0"
+    "doc": "markdown-toc -i README.md"
   },
   "repository": {
     "type": "git",
@@ -54,7 +53,6 @@
     "compare-versions": "^3.5.1",
     "cosmiconfig": "^6.0.0",
     "find-versions": "^3.2.0",
-    "opencollective-postinstall": "^2.0.2",
     "pkg-dir": "^4.2.0",
     "please-upgrade-node": "^3.2.0",
     "slash": "^3.0.0",


### PR DESCRIPTION
The use of post install scripts is somewhat controversial.
This blog gives some good context https://feross.org/funding-experiment-recap
Using just `npm fund` preserves the behavior of alerting users that there is an opportunity to contribute financially, without some of the drawbacks of running arbitrary scripts in `postinstall` comes with.