### PR TITLE
Show runtime node version when exit

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -6,7 +6,10 @@ const pkg = require('../package.json')
 // Node version isn't supported, skip
 pleaseUpgradeNode(pkg, {
   message(requiredVersion) {
-    return 'Husky requires Node ' + requiredVersion + ", can't run Git hook."
+    return 'Husky requires Node ' + 
+      requiredVersion +
+      ' (runtime: ' + process.version + ')' + 
+      ", can't run Git hook."
   }
 })
 

--- a/bin/run.js
+++ b/bin/run.js
@@ -6,10 +6,14 @@ const pkg = require('../package.json')
 // Node version isn't supported, skip
 pleaseUpgradeNode(pkg, {
   message(requiredVersion) {
-    return 'Husky requires Node ' + 
+    return (
+      'Husky requires Node ' +
       requiredVersion +
-      ' (runtime: ' + process.version + ')' + 
+      ' (runtime: ' +
+      process.version +
+      ')' +
       ", can't run Git hook."
+    )
   }
 })
 

--- a/husky.js
+++ b/husky.js
@@ -10,7 +10,7 @@ pleaseUpgradeNode(pkg, {
     return (
       'Husky requires Node ' +
       requiredVersion +
-      ' (runtime: ' + process.version + ')'
+      ' (runtime: ' + process.version + ')' +
       ', skipping Git hooks installation.'
     )
   }

--- a/husky.js
+++ b/husky.js
@@ -10,6 +10,7 @@ pleaseUpgradeNode(pkg, {
     return (
       'Husky requires Node ' +
       requiredVersion +
+      ' (runtime: ' + process.version + ')'
       ', skipping Git hooks installation.'
     )
   }


### PR DESCRIPTION
It's useful when some git GUI apps can't run `node -v` directly