### PR TITLE
Adding more supported formats to the README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can also do it manually. Move your existing hooks to `husky.hooks` field and
 }
 ```
 
-Starting with `1.0.0`, husky can be configured using `.huskyrc`, `.huskyrc.json`, `.huskyrc.js` or `husky.config.js` file.
+Starting with `1.0.0`, husky can be configured using `.huskyrc`, `.huskyrc.json`, `.huskyrc.yaml`, `huskyrc.yml`, `.huskyrc.js` or `husky.config.js` file.
 
 ```js
 // .huskyrc


### PR DESCRIPTION
As per the title, updating the documentation to list all the supported formats for configuration.

https://github.com/typicode/husky/issues/695