### PR TITLE
Add flag to fix relativeUserPkgDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ npm install husky --save-dev
 
 Verify that your version of Git is `>=2.13.0`.
 
-#### Lerna Workspaces and Monorepos
+#### Lerna, Monorepos, and Yarn Worksapces
 If your project has nested `node_modules` or you run `npm|yarn install` not from the project's root,
 simply set `HUSKY_RUN_FROM_ROOT` environment variable to force husky relative path to be `.`.
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ npm install husky --save-dev
 
 Verify that your version of Git is `>=2.13.0`.
 
+#### Lerna Workspaces and Monorepos
+If your project has nested `node_modules` or you run `npm|yarn install` not from the project's root,
+simply set `HUSKY_RUN_FROM_ROOT` environment variable to force husky relative path to be `.`.
+
 ## See also
 
 * [pkg-ok](https://github.com/typicode/pkg-ok) - Prevents publishing a module with bad paths or incorrect line endings

--- a/src/installer/bin.ts
+++ b/src/installer/bin.ts
@@ -31,7 +31,11 @@ function getDirs(
 
   const absoluteGitCommonDir = path.resolve(cwd, gitCommonDir)
   // Prefix can be an empty string
-  const relativeUserPkgDir = prefix || '.'
+  let relativeUserPkgDir = prefix || '.'
+  // https://github.com/typicode/husky/issues/677
+  if (['1', 'true'].includes(process.env.HUSKY_RUN_FROM_ROOT || '')) {
+    relativeUserPkgDir = '.'
+  }
 
   return { relativeUserPkgDir, absoluteGitCommonDir }
 }


### PR DESCRIPTION
# What
Per https://github.com/typicode/husky/issues/677, and @eduard-malakhov great explanation https://github.com/typicode/husky/issues/677#issuecomment-602520663

Fix a bug when running `yarn|npm install` from a sub `node_modules` in a monorepo/yarn workspaces project.

**Current:** the relative path to the project's root is set no `packages/someOther` when running from a package like `packages/someOther`.
**Expected**: To be able to force the relative path to the be the root of the project even when the `yarn|npm install` is running not from the root. 


