### PR TITLE
Add per-project global hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 ```
 
+### Per-Project commands (/project/dir/.huskyhook)
+
+Husky will source `/project/dir/.huskyhook` file if it exists before running hook scripts (also before the local command
+defined in `~/.huskyrc`). You can use it the same way you use `~/.huskyrc`, but being able to track the script with
+`git` and share it with your project colleagues.
+
 ### Multiple commands
 
 By design and just like `scripts` defined in `package.json`, husky will run hook scripts as a single command. 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Support this project with your organization. Your logo will show up here with a 
   * [Monorepos](#monorepos)
   * [Node version managers](#node-version-managers)
   * [Local commands (~/.huskyrc)](#local-commands-huskyrc)
+  * [Per-project commands (/project/dir/.huskyhook)](#per-project-commands-projectdirhuskyhook)
   * [Multiple commands](#multiple-commands)
   * [Troubleshoot](#troubleshoot)
     + [Debug messages](#debug-messages)
@@ -249,7 +250,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 ```
 
-### Per-Project commands (/project/dir/.huskyhook)
+### Per-project commands (/project/dir/.huskyhook)
 
 Husky will source `/project/dir/.huskyhook` file if it exists before running hook scripts (also before the local command
 defined in `~/.huskyrc`). You can use it the same way you use `~/.huskyrc`, but being able to track the script with

--- a/sh/husky.sh
+++ b/sh/husky.sh
@@ -63,6 +63,13 @@ if [ ! -f .huskyrc.js ] && [ ! -f husky.config.js ] && ! hookIsDefined; then
   exit 0
 fi
 
+# Source project-level global hook script. Not using ".huskyrc" name at the
+# project level because it's already used for other purposes.
+if [ -f "$PWD/.huskyhook" ]; then
+  debug "source $PWD/.huskyhook"
+  . "$PWD/.huskyhook"
+fi
+
 # Source user ~/.huskyrc
 if [ -f ~/.huskyrc ]; then
   debug "source ~/.huskyrc"

--- a/src/installer/__tests__/__snapshots__/scripts.ts.snap
+++ b/src/installer/__tests__/__snapshots__/scripts.ts.snap
@@ -92,6 +92,13 @@ if [ ! -f .huskyrc.js ] && [ ! -f husky.config.js ] && ! hookIsDefined; then
   exit 0
 fi
 
+# Source project-level global hook script. Not using \\".huskyrc\\" name at the
+# project level because it's already used for other purposes.
+if [ -f \\"$PWD/.huskyhook\\" ]; then
+  debug \\"source $PWD/.huskyhook\\"
+  . \\"$PWD/.huskyhook\\"
+fi
+
 # Source user ~/.huskyrc
 if [ -f ~/.huskyrc ]; then
   debug \\"source ~/.huskyrc\\"


### PR DESCRIPTION
## Description

This PR adds a mechanism to source project-specific scripts before executing any of the git hook scripts managed by Husky.

## Rationale
As stated in this comment ( https://github.com/typicode/husky/issues/385#issuecomment-665041037 ), some times is necessary to apply the `exec < /dev/tty` trick before reaching the point where we execute any NodeJS-related tool (in my specific case, because those tools are containerized).

Although it's possible to achieve that by using the `~/.huskyrc` file, using this solution forces all developers in a project to customize their development environments, when, precisely, tools such as `nvm`, or in my specific case `avatar-cli`, are designed to ease the creation of more homogeneous development environments.

Regarding why the file `.huskyhook` file is loaded before `~/.huskyrc`, I assumed that, whatever customization the developer has in its environment, it's probably there because she wants to override something, so I tried to preserve that.

Regarding the name of the file, I'm not attached to it, we could pick something else. I just wanted to use a name different than `.huskyrc` because that name has a different meaning when it's inside a project (Actually I find quite unfortunate that the same name is used for so different concepts: script and configuration).

Related to issue #385 .