### PR TITLE
fix: return non 0 exit code if an error occurred

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -48,6 +48,6 @@ try {
     help()
   }
 } catch(err) {
-  console.error(err);
-  process.exitCode = 1;
+  console.error(err)
+  process.exitCode = 1
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -30,19 +30,24 @@ Examples
 `)
 }
 
-if (arg === 'add') {
-  add({
-    cwd: process.cwd(),
-    hookName: params[0],
-    cmd: params[1],
-  })
-} else if (arg === 'install') {
-  install({
-    cwd: process.cwd(),
-    dir: params[0],
-  })
-} else if (['--version', '-v'].includes(arg)) {
-  version()
-} else {
-  help()
+try {
+  if (arg === 'add') {
+    add({
+      cwd: process.cwd(),
+      hookName: params[0],
+      cmd: params[1],
+    })
+  } else if (arg === 'install') {
+    install({
+      cwd: process.cwd(),
+      dir: params[0],
+    })
+  } else if (['--version', '-v'].includes(arg)) {
+    version()
+  } else {
+    help()
+  }
+} catch(err) {
+  console.error(err);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
Was originally fixed in https://github.com/typicode/husky/pull/633 but it doesn't seem to have survived the update to v5.

Non 0 exit code is required, otherwise Yarn 2 users may not see what went wrong.