### PR TITLE
Rename "prepublish" to "prepublishOnly" in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ yarn husky install
   "private": false,
   "scripts": {
     "postinstall": "husky install",
-    "prepublish": "pinst --disable",
+    "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   }
 }


### PR DESCRIPTION
Update the v5 documentation to be in line with [pinst](https://github.com/typicode/pinst) by replacing the ([deprecated](https://docs.npmjs.com/cli/v6/using-npm/scripts)) `"prepublish"` hook with `"prepublishOnly"`.
