### PR TITLE
Upgrade find-versions to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3028,11 +3028,11 @@
       }
     },
     "find-versions": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
-      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "^3.1.2"
       }
     },
     "flat-cache": {
@@ -6559,9 +6559,9 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ci-info": "^2.0.0",
     "compare-versions": "^3.6.0",
     "cosmiconfig": "^7.0.0",
-    "find-versions": "^3.2.0",
+    "find-versions": "^4.0.0",
     "opencollective-postinstall": "^2.0.2",
     "pkg-dir": "^4.2.0",
     "please-upgrade-node": "^3.2.0",


### PR DESCRIPTION
This PR fixes a security issues stemming from `semver-regex` which is pulled in via `find-versions`

`find-versions` 4.0.0 depends on `^3.1.2` of `semver-regex`. Previous
versions of `semver-regex` contained a [vulnernability][0]. This was
unlikely to affect `husky` because of how `find-versions` is used, but
the only breaking change in `find-versions` is increasing the minimum
Node.js verison to 10, which is the same as Husky's minimum.

[0]: https://app.snyk.io/vuln/SNYK-JS-SEMVERREGEX-1047770