### PR TITLE
Handle argument deconstruction in npx

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -52,11 +52,11 @@ switch (cmd) {
     break
   }
   case 'add': {
-    if (args.length === 0 || args.length > 2) {
+    if (args.length === 0) {
       help()
       process.exit(2)
     }
-    add(args[0], args[1])
+    add(args[0], args.splice(1).join(' '))
     break
   }
   case '--version': {


### PR DESCRIPTION
npx isn't honoring quotes around the command passed to husky add<filename> command.

There's currently a validation on add that prevents more than one from being passed. Removed this as it seems unnecessary, then joined the arguments after the cmd into a string to be passed to add.

Fixes #866 
Fixes #871 