### PR TITLE
docs: use npx vs. npm exec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Already using husky? See [Migrate from 4 to 5](https://typicode.github.io/husky/
 
 ```shell
 # npm
-npm install husky --save-dev && npm exec husky init
+npm install husky --save-dev && npx husky init
 
 # yarn
 yarn add husky --dev && yarn husky init


### PR DESCRIPTION
`npm exec` is only available on NPM 7+. Using `npx` is cross-compatible with npm 6 and 7.