### PR TITLE
fix: skipping installation/uninstallation inside node_modules (husky@4)

### DIFF
--- a/src/installer/__tests__/index.ts
+++ b/src/installer/__tests__/index.ts
@@ -36,17 +36,8 @@ function install({
   })
 }
 
-function uninstall({
-  gitCommonDir = '.git',
-  userPkgDir = '.',
-}: {
-  gitCommonDir?: string
-  userPkgDir?: string
-} = {}): void {
-  installer.uninstall({
-    absoluteGitCommonDir: path.join(tempDir, gitCommonDir),
-    userPkgDir,
-  })
+function uninstall(gitCommonDir = '.git'): void {
+  installer.uninstall(path.join(tempDir, gitCommonDir))
 }
 
 function mkdir(dirs: string[]): void {
@@ -175,7 +166,7 @@ describe('install', (): void => {
     expect(localScript).toMatch('cd "A/B/"')
     expectHookToExist('.git/hooks/pre-commit')
 
-    uninstall({ userPkgDir: relativeUserPkgDir })
+    uninstall()
     expect(exists('.git/hooks/husky.local.sh')).toBeFalsy()
     expect(exists('.git/hooks/pre-commit')).toBeFalsy()
   })
@@ -196,20 +187,9 @@ describe('install', (): void => {
     expect(localScript).toMatch('cd "."')
     expectHookToExist('.git/modules/A/B/hooks/pre-commit')
 
-    uninstall({ gitCommonDir, userPkgDir })
+    uninstall(gitCommonDir)
     expect(exists('.git/modules/A/B/hooks/husky.local.sh')).toBeFalsy()
     expect(exists('.git/modules/A/B/hooks/pre-commit')).toBeFalsy()
-  })
-
-  it('should not install from node_modules/A', (): void => {
-    const userPkgDir = 'node_modules/A'
-
-    mkdir([userPkgDir])
-    writeFile('node_modules/A/package.json', '{}')
-    writeFile('package.json', pkg)
-
-    install({ userPkgDir })
-    expect(exists('.git/hooks/pre-commit')).toBeFalsy()
   })
 
   it('should not install hooks in CI server', (): void => {

--- a/src/installer/checkGitVersion.ts
+++ b/src/installer/checkGitVersion.ts
@@ -8,8 +8,8 @@ export function checkGitVersion(): void {
   if (status !== 0) {
     throw new Error(
       `git --version command failed. Got ${status} exit code and message: ${String(
-        stderr,
-      )}.`,
+        stderr
+      )}.`
     )
   }
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -6,12 +6,6 @@ import { createHooks, removeHooks } from './hooks'
 import { createLocalScript, removeLocalScript } from './localScript'
 import { createMainScript, removeMainScript } from './mainScript'
 
-// This prevents the case where someone would want to debug a node_module that has
-// husky as devDependency and run npm install from node_modules directory
-function isInNodeModules(dir: string): boolean {
-  return dir.indexOf('node_modules') !== -1
-}
-
 function getGitHooksDir(gitDir: string): string {
   return path.join(gitDir, 'hooks')
 }
@@ -38,13 +32,6 @@ export function install({
     return
   }
 
-  if (isInNodeModules(userPkgDir)) {
-    console.log(
-      'Trying to install from node_modules directory, skipping Git hooks installation.'
-    )
-    return
-  }
-
   // Create hooks directory if it doesn't exist
   const gitHooksDir = getGitHooksDir(absoluteGitCommonDir)
   if (!fs.existsSync(gitHooksDir)) {
@@ -57,20 +44,7 @@ export function install({
   createMainScript(gitHooksDir)
 }
 
-export function uninstall({
-  absoluteGitCommonDir,
-  userPkgDir,
-}: {
-  absoluteGitCommonDir: string
-  userPkgDir: string
-}): void {
-  if (isInNodeModules(userPkgDir)) {
-    console.log(
-      'Trying to uninstall from node_modules directory, skipping Git hooks uninstallation.'
-    )
-    return
-  }
-
+export function uninstall(absoluteGitCommonDir: string): void {
   // Remove hooks
   const gitHooksDir = getGitHooksDir(absoluteGitCommonDir)
   removeHooks(gitHooksDir)


### PR DESCRIPTION
We use `husky@4` in our company as a dependency for our own "husky" package for configuring hooks in our own vcs system. This vcs system is similar to git but has some important features for our company. I moved the logic of skipping installation/uninstallation from `installer/index.ts` -> `installer/bin.ts` because when this package is installed/uninstalled as a transitive dependency it confuses users with errors messages. 
Also, I think these changes could be useful for users with other vcs systems and who also for some reason use this package. 

