### PR TITLE
Add required uninstallation step

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ If `npm test` command fails, your commit will be automatically aborted.
 ### Uninstall
 
 ```shell
-npm uninstall husky
+npm uninstall husky && git config --unset core.hooksPath
 ```
 
 ## Yarn v2


### PR DESCRIPTION
After uninstalling husky v5 with `npm uninstall`, husky v4 didn't work. As it turned out, the `core.hooksPath` was still set to `.husky` so I had to unset the git config value for a clean uninstallation of husky v5.