### PR TITLE
docs: update yarn install to yarn add

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,7 @@ npm uninstall husky
 1. Install `husky`
 
 ```shell
-yarn install husky --save-dev
+yarn add husky --dev
 yarn add pinst --dev # if your package is not private
 ```
 


### PR DESCRIPTION
CLI was throwing a warning when using `yarn install husky --save-dev`, so this PR updates the command in the docs to `yarn add husky --dev`