### PR TITLE
refactor(husky): remove redundant exit on husky.sh

### DIFF
--- a/packages/husky/src/husky.sh
+++ b/packages/husky/src/husky.sh
@@ -23,8 +23,7 @@ if [ -z "$husky_skip_init" ]; then
 
   if [ $exitCode != 0 ]; then
     echo "husky - $hook_name hook exited with code $exitCode (error)"
-    exit $exitCode
   fi
 
-  exit 0
+  exit $exitCode
 fi


### PR DESCRIPTION
Since the `exitCode` is defined on line 22, It is possible to directly exit on line 28 and keep the `exitCode`, Line 24 only checks if `exitCode` is not 0 and echoes the error.