### PR TITLE
Don't create .gitignore

### DIFF
--- a/packages/husky/src/index.ts
+++ b/packages/husky/src/index.ts
@@ -31,7 +31,7 @@ export function install(dir = '.husky'): void {
     fs.mkdirSync(path.join(dir, '_'), { recursive: true })
 
     // Create .husky/.gitignore
-    fs.writeFileSync(path.join(dir, '.gitignore'), '_\n')
+    // fs.writeFileSync(path.join(dir, '.gitignore'), '_\n')
 
     // Copy husky.sh to .husky/_/husky.sh
     fs.copyFileSync(


### PR DESCRIPTION
This would close #944.

Current behavior:

- Husky creates a .gitignore file that ignores all the scripts in `.husky/_`
- Anyone creating a new git branch has to run `npm run prepare`... every single time
- Anyone using custom scripts (like `common.sh` [recommended in the docs](https://typicode.github.io/husky/#/?id=yarn-on-windows)) has to copy them manually

Desired behavior:

- Husky doesn't create a .gitignore file at all
- Husky reduces maintainability instead of increasing it
- The docs for every project using husky don't have to be updated to say "Please run `npm run prepare` if you ever make a new git branch... or clone the git repo without npm install... or ever want to use husky"