### PR TITLE
docs: add git init troubleshoot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -336,6 +336,8 @@ Ensure that you don't have a typo in your filename. For example, `precommit` or 
 
 Verify hooks permissions, they should be executable. This is automatically set when using `husky add` command but you can run `chmod +x .husky/<hookname>` to fix that.
 
+Ensure that you run `husky install` after `git init`.
+
 Check that your version of Git is greater than `2.9`.
 
 ## Yarn on Windows


### PR DESCRIPTION
I was setting up a project from the remnants of another, and I only ran `git init` after setting up everything. It goes without a saying that the hooks didn't work.

If facing this situation seems unlikely, feel free to close the PR.