### PR TITLE
docs: align the examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -438,6 +438,7 @@ If you were calling directly locally installed binaries, **you need to run them 
 # .husky/pre-commit (v6)
 # ...
 npx --no-install jest
+# or
 yarn jest
 ```
 


### PR DESCRIPTION
The "Locally installed binaries" section was missing a `# or` comment between the `npx` and `yarn` example. I brought the comment directly from the "HUSKY_GIT_PARAMS" section.