### PR TITLE
fix: cover case where git rev-parse returns null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const git = (args: string[]): cp.SpawnSyncReturns<Buffer> =>
 
 export function install(dir = '.husky'): void {
   // Ensure that we're inside a git repository
-  if (git(['rev-parse']).status) {
+  if (git(['rev-parse']).status !== 0) {
     return
   }
 


### PR DESCRIPTION
This resolves [this issue](https://github.com/typicode/husky/issues/1000) by covering for the case that `git rev-parse` returns null, which may be the case in a CI Docker image that does not bundle the git cli