### PR TITLE
ci: update actions/setup-node to v2, enable cache

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+    cache: 'npm'
     - name: npm 7
       run: npm i -g npm@7
     - run: npm ci --ignore-scripts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm 7

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    cache: 'npm'
+        cache: 'npm'
     - name: npm 7
       run: npm i -g npm@7
     - run: npm ci --ignore-scripts


### PR DESCRIPTION
## Changes:

- Update `actions/setup-node` to `v2`
- Enable built-in cache for npm packages that comes with `actions/setup-node@v2.2.0` (optional)

## Context:

Closes #1007.

[Release notes for `actions/setup-node v2.2.0`](https://github.com/actions/setup-node/releases/tag/v2.2.0)