### PR TITLE
Fix pre-commit hook in WebStorm under macOS

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
-    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
   }
 
   readonly hook_name="$(basename "$0")"


### PR DESCRIPTION
I do not know why this works but this version of `husky.sh` now works well both in terminal and in WebStorm