### PR TITLE
Specify `npm set-script` is only available starting NPM 7.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install husky --save-dev
 Edit `package.json > prepare` script and run it once:
 
 ```sh
+# Only available on NPM >= 7.X
 npm set-script prepare "husky install"
 npm run prepare
 ```


### PR DESCRIPTION
Specify `npm set-script` is only available starting NPM 7.X

https://blog.npmjs.org/post/636604708661886976/release-v710.html