### PR TITLE
docs: fix uninstall via npm

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,7 +133,7 @@ If `npm test` command fails, your commit will be automatically aborted.
 ### Uninstall
 
 ```shell
-npm uninstall husky
+npm uninstall husky && git config --unset core.hooksPath
 ```
 
 ## Yarn 2


### PR DESCRIPTION
I want to uninstall husky for learning purpose. But I find just using `npm uninstall husky` don't work unless I removed `.husky`.
Finally, I find `git config --unset core.hooksPath` in the part of yarn and it works. So, I create this PR to add it.

By the way, Husky is cool :)