### PR TITLE
fix: bash scripts should end with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.sh linguist-language=JavaScript
+*.sh text eol=LF linguist-language=JavaScript
 *.ts linguist-language=JavaScript


### PR DESCRIPTION
This makes sure that the files when checked out from git will have the correct line ending

https://github.com/typicode/husky/issues/1010#issuecomment-898606055