### PR TITLE
Use /usr/bin/env sh instead of direct path of sh

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 npm test

--- a/docs/README.md
+++ b/docs/README.md
@@ -394,7 +394,7 @@ fi
 2. Source it in in places where Yarn is used to run commands:
 
 ```shell
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/husky.sh
+++ b/husky.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
     if [ "$HUSKY_DEBUG" = "1" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export function set(file: string, cmd: string): void {
 
   fs.writeFileSync(
     file,
-    `#!/bin/sh
+    `#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 ${cmd}


### PR DESCRIPTION
According with the best practices of shell scripting, the right way to invoke the _shebang_ is `#!/usr/bin/env shell`

Reference: https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html