### PR TITLE
install method update and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ npm install husky --save-dev
 
 # Usage
 
-Edit `package.json > prepare` script and run it once:
+Run install script once:
 
 ```sh
-npm set-script prepare "husky install"
-npm run prepare
+npx husky install
 ```
 
 Add a hook:


### PR DESCRIPTION
`npm set-script prepare "husky install"` is not recognized and will not work properly, maybe only under certain circumstances:

```
$ npm set-script prepare "husky install"

Usage: npm <command>

where <command> is one of:
    access, adduser, audit, bin, bugs, c, cache, ci, cit,
    clean-install, clean-install-test, completion, config,
    create, ddp, dedupe, deprecate, dist-tag, docs, doctor,
    edit, explore, fund, get, help, help-search, hook, i, init,
    install, install-ci-test, install-test, it, link, list, ln,
    login, logout, ls, org, outdated, owner, pack, ping, prefix,
    profile, prune, publish, rb, rebuild, repo, restart, root,
    run, run-script, s, se, search, set, shrinkwrap, star,
    stars, start, stop, t, team, test, token, tst, un,
    uninstall, unpublish, unstar, up, update, v, version, view,
    whoami

npm <command> -h  quick help on <command>
npm -l            display full usage info
npm help <term>   search for help on <term>
npm help npm      involved overview

Specify configs in the ini-formatted file:
    /Users/___YOUR_USERNAME___/.npmrc
or on the command line via: npm <command> --key value
Config info can be viewed via: npm help config

npm@6.13.4 /Users/___YOUR_USERNAME___/.nvm/versions/node/v12.14.1/lib/node_modules/npm

Did you mean this?
    run-script
```

It is much easier/faster to just install through `npx`.