### PR TITLE
Do not depend on the exact location of the 'sh' interpreter

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 npm test

--- a/docs/README.md
+++ b/docs/README.md
@@ -399,7 +399,7 @@ fi
 2. Source it in in places where Yarn is used to run commands:
 
 ```shell
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/husky.sh
+++ b/husky.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
     if [ "$HUSKY_DEBUG" = "1" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export function set(file: string, cmd: string): void {
 
   fs.writeFileSync(
     file,
-    `#!/bin/sh
+    `#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
 ${cmd}


### PR DESCRIPTION
Some Unix systems do not have sh at the specified location: `/bin/sh`. In my instance, I'm using [NixOS](https://nixos.org/), which also lacks it.

Using `/usr/bin/env sh` instead uses the `sh` executable from users `$PATH`, which should be more portable and also it makes it possible for the user to choose which 'sh' to use.

See: https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability