### PR TITLE
add `husky -` prefix to logged global error messages

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -38,6 +38,6 @@ try {
   cmds[cmd] ? cmds[cmd]() : help(0)
 } catch (e) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  console.error(e.message)
+  console.error(`husky - ${e.message}`)
   process.exit(1)
 }


### PR DESCRIPTION
Hiya,

Spent some time today debugging an issue that I eventually traced back to husky, would have been nice to have the error message identified as such.

Admit this is probably more a yarn issue as all yarn gave me to go on was:

```
➤ YN0000: │ root@workspace:. STDERR fatal: not a git repository (or any of the parent directories): .git
```

But would appreciate this workaround being added, as it also bring it in line with [your other logging](https://github.com/typicode/husky/blob/main/src/index.ts#L6).

Cheers!