### PR TITLE
Custom logger feature

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -282,6 +282,18 @@ if (!isCi) {
 }
 ```
 
+You can also use your own logging functions if needed:
+
+```js
+// prepare.js
+const { configure } = require('husky)
+const husky = configure({
+  log: (msg) => console.log(msg),
+  error: (msg) => console.error(`Something went bad: ${msg}`)
+})
+husky.install()
+```
+
 Or make `prepare` script fail silently if husky is not installed:
 
 ```json

--- a/docs/README.md
+++ b/docs/README.md
@@ -286,7 +286,7 @@ You can also use your own logging functions if needed:
 
 ```js
 // prepare.js
-const { configure } = require('husky)
+const { configure } = require('husky')
 const husky = configure({
   log: (msg) => console.log(msg),
   error: (msg) => console.error(`Something went bad: ${msg}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^4.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,10 @@ import fs = require('fs')
 import p = require('path')
 
 interface Options {
-  log: (msg: string) => void
-  error: (msg: string) => void
+  logger: {
+    log: (msg: string) => void
+    error: (msg: string) => void
+  }
 }
 
 type CustomOptions = Partial<Options>
@@ -18,8 +20,10 @@ interface Husky {
 
 // Default options
 const defaultOptions: Options = {
-  log: (msg: string): void => console.log(`husky - ${msg}`),
-  error: (msg: string): void => console.error(`husky - ${msg}`),
+  logger: {
+    log: (msg: string): void => console.log(`husky - ${msg}`),
+    error: (msg: string): void => console.error(`husky - ${msg}`),
+  },
 }
 
 // Git command
@@ -29,11 +33,11 @@ const git = (args: string[]): cp.SpawnSyncReturns<Buffer> =>
 const defaultHusky = configure()
 
 export function configure(customOptions: CustomOptions = {}): Husky {
-  const options: Options = { ...defaultOptions, ...customOptions }
+  const { logger }: Options = { ...defaultOptions, ...customOptions }
   return {
     install(dir = '.husky'): void {
       if (process.env.HUSKY === '0') {
-        options.log('HUSKY env variable is set to 0, skipping install')
+        logger.log('HUSKY env variable is set to 0, skipping install')
         return
       }
 
@@ -76,11 +80,11 @@ export function configure(customOptions: CustomOptions = {}): Husky {
           throw error
         }
       } catch (e) {
-        options.error('Git hooks failed to install')
+        logger.error('Git hooks failed to install')
         throw e
       }
 
-      options.log('Git hooks installed')
+      logger.log('Git hooks installed')
     },
 
     set(file: string, cmd: string): void {
@@ -101,13 +105,13 @@ ${cmd}
         { mode: 0o0755 },
       )
 
-      options.log(`created ${file}`)
+      logger.log(`created ${file}`)
     },
 
     add(file: string, cmd: string): void {
       if (fs.existsSync(file)) {
         fs.appendFileSync(file, `${cmd}\n`)
-        options.log(`updated ${file}`)
+        logger.log(`updated ${file}`)
       } else {
         this.set(file, cmd)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,14 @@ import cp = require('child_process')
 import fs = require('fs')
 import p = require('path')
 
-interface Options {
-  logger: {
-    log: (msg: string) => void
-    error: (msg: string) => void
-  }
+interface Logger {
+  log: (msg: string) => void
+  error: (msg: string) => void
 }
 
-type CustomOptions = Partial<Options>
+interface Options {
+  logger?: Partial<Logger>
+}
 
 interface Husky {
   install: (dir: string) => void
@@ -18,12 +18,9 @@ interface Husky {
   uninstall: () => void
 }
 
-// Default options
-const defaultOptions: Options = {
-  logger: {
-    log: (msg: string): void => console.log(`husky - ${msg}`),
-    error: (msg: string): void => console.error(`husky - ${msg}`),
-  },
+const defaultLogger: Logger = {
+  log: (msg: string): void => console.log(`husky - ${msg}`),
+  error: (msg: string): void => console.error(`husky - ${msg}`),
 }
 
 // Git command
@@ -32,8 +29,12 @@ const git = (args: string[]): cp.SpawnSyncReturns<Buffer> =>
 
 const defaultHusky = configure()
 
-export function configure(customOptions: CustomOptions = {}): Husky {
-  const { logger }: Options = { ...defaultOptions, ...customOptions }
+export function configure(customOptions: Options = {}): Husky {
+  const logger: Logger = {
+    log: customOptions?.logger?.log || defaultLogger.log,
+    error: customOptions?.logger?.log || defaultLogger.error,
+  }
+
   return {
     install(dir = '.husky'): void {
       if (process.env.HUSKY === '0') {
@@ -122,6 +123,7 @@ ${cmd}
     },
   }
 }
+
 export const install = defaultHusky.install.bind(defaultHusky)
 export const set = defaultHusky.set.bind(defaultHusky)
 export const add = defaultHusky.add.bind(defaultHusky)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,92 +2,126 @@ import cp = require('child_process')
 import fs = require('fs')
 import p = require('path')
 
-// Logger
-const l = (msg: string): void => console.log(`husky - ${msg}`)
+interface Options {
+  log: (msg: string) => void
+  error: (msg: string) => void
+}
+
+interface CustomOptions {
+  log?: (msg: string) => void
+  error?: (msg: string) => void
+}
+
+interface Husky {
+  install: (dir: string) => void
+  set: (file: string, cmd: string) => void
+  add: (file: string, cmd: string) => void
+  uninstall: () => void
+}
+
+// Default options
+const defaultOptions: Options = {
+  log: (msg: string): void => console.log(`husky - ${msg}`),
+  error: (msg: string): void => console.error(`husky - ${msg}`),
+}
 
 // Git command
 const git = (args: string[]): cp.SpawnSyncReturns<Buffer> =>
   cp.spawnSync('git', args, { stdio: 'inherit' })
 
-export function install(dir = '.husky'): void {
-  if (process.env.HUSKY === '0') {
-    l('HUSKY env variable is set to 0, skipping install')
-    return
-  }
+const defaultHusky = configure()
 
-  // Ensure that we're inside a git repository
-  // If git command is not found, status is null and we should return.
-  // That's why status value needs to be checked explicitly.
-  if (git(['rev-parse']).status !== 0) {
-    return
-  }
+export function configure(customOptions: CustomOptions = {}): Husky {
+  const options: Options = { ...defaultOptions, ...customOptions }
+  return {
+    install(dir = '.husky'): void {
+      if (process.env.HUSKY === '0') {
+        options.log('HUSKY env variable is set to 0, skipping install')
+        return
+      }
 
-  // Custom dir help
-  const url = 'https://typicode.github.io/husky/#/?id=custom-directory'
+      // Ensure that we're inside a git repository
+      // If git command is not found, status is null and we should return.
+      // That's why status value needs to be checked explicitly.
+      if (git(['rev-parse']).status !== 0) {
+        return
+      }
 
-  // Ensure that we're not trying to install outside of cwd
-  if (!p.resolve(process.cwd(), dir).startsWith(process.cwd())) {
-    throw new Error(`.. not allowed (see ${url})`)
-  }
+      // Custom dir help
+      const url = 'https://typicode.github.io/husky/#/?id=custom-directory'
 
-  // Ensure that cwd is git top level
-  if (!fs.existsSync('.git')) {
-    throw new Error(`.git can't be found (see ${url})`)
-  }
+      // Ensure that we're not trying to install outside of cwd
+      if (!p.resolve(process.cwd(), dir).startsWith(process.cwd())) {
+        throw new Error(`.. not allowed (see ${url})`)
+      }
 
-  try {
-    // Create .husky/_
-    fs.mkdirSync(p.join(dir, '_'), { recursive: true })
+      // Ensure that cwd is git top level
+      if (!fs.existsSync('.git')) {
+        throw new Error(`.git can't be found (see ${url})`)
+      }
 
-    // Create .husky/_/.gitignore
-    fs.writeFileSync(p.join(dir, '_/.gitignore'), '*')
+      try {
+        // Create .husky/_
+        fs.mkdirSync(p.join(dir, '_'), { recursive: true })
 
-    // Copy husky.sh to .husky/_/husky.sh
-    fs.copyFileSync(p.join(__dirname, '../husky.sh'), p.join(dir, '_/husky.sh'))
+        // Create .husky/_/.gitignore
+        fs.writeFileSync(p.join(dir, '_/.gitignore'), '*')
 
-    // Configure repo
-    const { error } = git(['config', 'core.hooksPath', dir])
-    if (error) {
-      throw error
-    }
-  } catch (e) {
-    l('Git hooks failed to install')
-    throw e
-  }
+        // Copy husky.sh to .husky/_/husky.sh
+        fs.copyFileSync(
+          p.join(__dirname, '../husky.sh'),
+          p.join(dir, '_/husky.sh'),
+        )
 
-  l('Git hooks installed')
-}
+        // Configure repo
+        const { error } = git(['config', 'core.hooksPath', dir])
+        if (error) {
+          throw error
+        }
+      } catch (e) {
+        options.error('Git hooks failed to install')
+        throw e
+      }
 
-export function set(file: string, cmd: string): void {
-  const dir = p.dirname(file)
-  if (!fs.existsSync(dir)) {
-    throw new Error(
-      `can't create hook, ${dir} directory doesn't exist (try running husky install)`,
-    )
-  }
+      options.log('Git hooks installed')
+    },
 
-  fs.writeFileSync(
-    file,
-    `#!/usr/bin/env sh
+    set(file: string, cmd: string): void {
+      const dir = p.dirname(file)
+      if (!fs.existsSync(dir)) {
+        throw new Error(
+          `can't create hook, ${dir} directory doesn't exist (try running husky install)`,
+        )
+      }
+
+      fs.writeFileSync(
+        file,
+        `#!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
 ${cmd}
 `,
-    { mode: 0o0755 },
-  )
+        { mode: 0o0755 },
+      )
 
-  l(`created ${file}`)
-}
+      options.log(`created ${file}`)
+    },
 
-export function add(file: string, cmd: string): void {
-  if (fs.existsSync(file)) {
-    fs.appendFileSync(file, `${cmd}\n`)
-    l(`updated ${file}`)
-  } else {
-    set(file, cmd)
+    add(file: string, cmd: string): void {
+      if (fs.existsSync(file)) {
+        fs.appendFileSync(file, `${cmd}\n`)
+        options.log(`updated ${file}`)
+      } else {
+        this.set(file, cmd)
+      }
+    },
+
+    uninstall(): void {
+      git(['config', '--unset', 'core.hooksPath'])
+    },
   }
 }
-
-export function uninstall(): void {
-  git(['config', '--unset', 'core.hooksPath'])
-}
+export const install = defaultHusky.install.bind(defaultHusky)
+export const set = defaultHusky.set.bind(defaultHusky)
+export const add = defaultHusky.add.bind(defaultHusky)
+export const uninstall = defaultHusky.uninstall.bind(defaultHusky)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,7 @@ interface Options {
   error: (msg: string) => void
 }
 
-interface CustomOptions {
-  log?: (msg: string) => void
-  error?: (msg: string) => void
-}
+type CustomOptions = Partial<Options>
 
 interface Husky {
   install: (dir: string) => void

--- a/test/8_custom_logger.sh
+++ b/test/8_custom_logger.sh
@@ -1,0 +1,29 @@
+. "$(dirname "$0")/functions.sh"
+setup
+install
+
+npx --no-install husky install
+
+# Test core.hooksPath
+expect_hooksPath_to_be ".husky"
+
+# Test pre-commit
+git add package.json
+echo '
+const { configure } = require("husky");
+const { install, set, add } = configure({
+log: (msg) => console.log(`HUSKY LOG - ${msg}`),
+});
+install();
+set(".husky/pre-commit", "");
+add(".husky/pre-commit", "echo \"pre-commit\" && exit 1");
+' > custom_logger.js
+node custom_logger.js | grep -q "HUSKY LOG" || (
+  echo "Custom logger was not taken into account"
+  exit 1
+)
+expect 1 "git commit -m foo"
+
+# Uninstall
+npx --no-install husky uninstall
+expect 1 "git config core.hooksPath"

--- a/test/8_custom_logger.sh
+++ b/test/8_custom_logger.sh
@@ -12,7 +12,10 @@ git add package.json
 echo '
 const { configure } = require("husky");
 const { install, set, add } = configure({
-log: (msg) => console.log(`HUSKY LOG - ${msg}`),
+  logger: {
+    log: (msg) => console.log(`HUSKY LOG - ${msg}`),
+    error: (msg) => console.error(`HUSKY ERROR - ${msg}`),
+  },
 });
 install();
 set(".husky/pre-commit", "");

--- a/test/all.sh
+++ b/test/all.sh
@@ -8,3 +8,4 @@ sh test/4_not-git-dir.sh
 sh test/5_set-add.sh
 sh test/6_git_command_not_found.sh
 sh test/7_command_not_found.sh
+sh test/8_custom_logger.sh


### PR DESCRIPTION
Hello @typicode,

I am using husky as part of a scaffolding project and needed to pass husky the logger used from the outer scope.

I do not know if this feature is something you might want to add in husky but here it is.
I am quite new to typescript so I might have made some mistakes when specifying the logger interface.
This interface defines 3 levels of log, one of which is currently unused (warn), I can remove it if you feel like it will never be necessary or if you want to add it later.

I have also added a test case and extended the documentation a bit.
I am open to any advice/modification to make this go upstream if this is something you are ok with.

Gautaz

**EDIT:**

I have replaced the `logger` argument by `customOptions` for the `configure` method, it seems more relevant and `CustomOptions` can later be extended with additional features.

I have also removed the `warn` logger as it was not used (it can be added later anyway if needed).