### PR TITLE
Actually set 'husky_skip_init' as readonly in `./husky.sh`

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -19,7 +19,8 @@ if [ -z "$husky_skip_init" ]; then
     . ~/.huskyrc
   fi
 
-  export readonly husky_skip_init=1
+  readonly husky_skip_init=1
+  export husky_skip_init
   sh -e "$0" "$@"
   exitCode="$?"
 


### PR DESCRIPTION
Previously, the `husky.sh` script would export the empty 'readonly' variable, along with 'husky_skip_init' which has a value of 1.

Now, the script sets 'husky_skip_init' to 1, and properly gives is the 'readonly' and 'exported' attributes.