### PR TITLE
Directly re-execute the current script

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -21,7 +21,7 @@ if [ -z "$husky_skip_init" ]; then
 
   readonly husky_skip_init=1
   export husky_skip_init
-  sh -e "$0" "$@"
+  env "$0" "$@"
   exitCode="$?"
 
   if [ $exitCode != 0 ]; then


### PR DESCRIPTION
The current `husky.sh` re-executes the current script with `sh -e`, completely ignoring whatever shebang line is in the script. This causes failures when scripts are expecting bash-specific features but `/bin/sh` is linked to something that is not bash (ex: `/bin/sh` is `dash` on Ubuntu).

This change makes it re-execute using `env` instead which will just run the script. This is safe because by definition [git hooks have to be executable](https://git-scm.com/docs/githooks/2.24.0):

> Hooks that don’t have the executable bit set are ignored.

Fixes #971.

