### PR TITLE
Update `funding` key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,16 @@
   ],
   "homepage": "https://typicode.github.io/husky",
   "repository": "typicode/husky",
-  "funding": "https://github.com/sponsors/typicode",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/typicode"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/husky"
+    }
+  ],
   "license": "MIT",
   "author": "Typicode <typicode@gmail.com>",
   "bin": "lib/bin.js",


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to direct dependencies, so having this metadata complete in package.json files allows us to programatically know how we can fund them. The `funding` key in package.json accepts a list of objects with all the possible ways to fund, see [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!