### PR TITLE
Force `basename`/`dirname` to treat `$0` as an argument

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
 npm test

--- a/docs/README.md
+++ b/docs/README.md
@@ -406,8 +406,8 @@ fi
 
 ```shell
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-. "$(dirname "$0")/common.sh"
+. "$(dirname -- "$0")/_/husky.sh"
+. "$(dirname -- "$0")/common.sh"
 
 yarn ...
 ```

--- a/husky.sh
+++ b/husky.sh
@@ -6,7 +6,7 @@ if [ -z "$husky_skip_init" ]; then
     fi
   }
 
-  readonly hook_name="$(basename "$0")"
+  readonly hook_name="$(basename -- "$0")"
   debug "starting $hook_name..."
 
   if [ "$HUSKY" = "0" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export function set(file: string, cmd: string): void {
   fs.writeFileSync(
     file,
     `#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
 ${cmd}
 `,

--- a/test/1_default.sh
+++ b/test/1_default.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 install
 

--- a/test/2_in-sub-dir.sh
+++ b/test/2_in-sub-dir.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 install
 

--- a/test/3_from-sub-dir.sh
+++ b/test/3_from-sub-dir.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 
 # Example:

--- a/test/4_not-git-dir.sh
+++ b/test/4_not-git-dir.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 install
 

--- a/test/5_set-add.sh
+++ b/test/5_set-add.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 install
 

--- a/test/6_git_command_not_found.sh
+++ b/test/6_git_command_not_found.sh
@@ -1,4 +1,4 @@
-. "$(dirname "$0")/functions.sh"
+. "$(dirname -- "$0")/functions.sh"
 setup
 install
 

--- a/test/functions.sh
+++ b/test/functions.sh
@@ -2,7 +2,7 @@
 set -eu
 
 setup() {
-  name="$(basename $0)"
+  name="$(basename -- $0)"
   testDir="/tmp/husky-test-$name"
   echo
   echo "-------------------"


### PR DESCRIPTION
`basename`/`dirname` will treat `$0` as an option if it starts with a `-`; e.g. for `-husky`:

```sh
dirname: invalid option -- 'h'
Try 'dirname --help' for more information.
```

Why did my directory start with a hyphen instead of a dot in the first place? I'd... rather not answer this, but it's related to my setup and not a bug in this project.