### PR TITLE
chore: remove git.io

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export function install(dir = '.husky'): void {
   }
 
   // Custom dir help
-  const url = 'https://git.io/Jc3F9'
+  const url = 'https://typicode.github.io/husky/#/?id=custom-directory'
 
   // Ensure that we're not trying to install outside of cwd
   if (!p.resolve(process.cwd(), dir).startsWith(process.cwd())) {


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/