### PR TITLE
Use number comparators when comparing exit codes

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -24,13 +24,13 @@ if [ -z "$husky_skip_init" ]; then
   sh -e "$0" "$@"
   exitCode="$?"
 
-  if [ $exitCode != 0 ]; then
+  if [ "$exitCode" -ne 0 ]; then
     echo "husky - $hook_name hook exited with code $exitCode (error)"
   fi
 
-  if [ $exitCode = 127 ]; then
+  if [ "$exitCode" -eq 127 ]; then
     echo "husky - command not found in PATH=$PATH"
   fi
 
-  exit $exitCode
+  exit "$exitCode"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^4.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/test/functions.sh
+++ b/test/functions.sh
@@ -34,7 +34,7 @@ expect() {
   sh -c "$2"
   exitCode="$?"
   set -e
-  if [ $exitCode != "$1" ]; then
+  if [ "$exitCode" -ne "$1" ]; then
     error "expect command \"$2\" to exit with code $1 (got $exitCode)"
   fi
 }


### PR DESCRIPTION
This has exploded on me once before - when an equivalent of `exitCode` could be coerced to a number, but was an actual string.

Updated Node version in the lockfile as a by-product.