### PR TITLE
npx option --no-install replaced with --no -- due to deprecation

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no-install commitlint --edit "$1"
+npx --no -- commitlint --edit "$1"


### PR DESCRIPTION
npx `--no-install` option is deprecated (see [npm docs](https://docs.npmjs.com/cli/v8/commands/npx#compatibility-with-older-npx-versions)).

Use `--no --` instead