### PR TITLE
docs: README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install husky --save-dev
 Edit `package.json > prepare` script and run it once:
 
 ```sh
-npm pkg set prepare="husky install"
+npm pkg set scripts.prepare="husky install"
 npm run prepare
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install husky --save-dev
 Edit `package.json > prepare` script and run it once:
 
 ```sh
-npm set-script prepare "husky install"
+npm pkg set prepare="husky install"
 npm run prepare
 ```
 


### PR DESCRIPTION
replacing depricated `npm set-script` with `npm pkg set`
(#1150)