### PR TITLE
Docs/update husky docs to make them more intuitive

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -53,7 +53,7 @@ e.g. `prepare`.
 
 
 ```shell
-npm set-script prepare "husky install"
+npm pkg set scripts.prepare="husky install"
 ```
 
 You should have:

--- a/.github/README.md
+++ b/.github/README.md
@@ -8,34 +8,64 @@ Husky improves your commits and more 🐶 _woof!_
 
 # Install
 
+## Easy install (reccomended)
+
+`husky-init` is a one-time command to configure a project with husky.
+
+It installs husky into your project and auto-configures your package.json,
+ensuring that every time you run `yarn|npm install` git is then configured to
+use your hooks (so you don't have to worry about it again).
+
+```shell
+npx husky-init && npm install       # npm
+npx husky-init && yarn              # Yarn 1
+yarn dlx husky-init --yarn2 && yarn # Yarn 2+
+pnpm dlx husky-init && pnpm install # pnpm
 ```
-npm install husky -D
+
+It will:
+* install husky
+* modify `package.json` (adding a
+[`prepare`](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish)
+script)
+* create a sample `pre-commit` hook that you can edit. By default this runs
+  `npm test` when you commit.
+
+## Manual Install
+
+1. Install `husky`
+
+```shell
+npm install husky --save-dev
+yarn add --dev husky
 ```
 
-# Usage
+2. Enable Git hooks
 
-Edit `package.json > prepare` script and run it once:
+```shell
+npx husky install # will configure git to use .husky/ by default
+```
 
-```sh
+3. To automatically have Git hooks enabled after every npm/yarn install, edit
+`package.json` to use one of the [npm/yarm lifecyle
+hooks](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish)
+e.g. `prepare`.
+
+
+```shell
 npm set-script prepare "husky install"
-npm run prepare
 ```
 
-Add a hook:
+You should have:
 
-```sh
-npx husky add .husky/pre-commit "npm test"
-git add .husky/pre-commit
+```js
+// package.json
+{
+  "scripts": {
+    "prepare": "husky install"
+  }
+}
 ```
-
-Make a commit:
-
-```sh
-git commit -m "Keep calm and commit"
-# `npm test` will run every time you commit
-```
-
-_For more use cases (project in sub-directory, custom directory, CI support, ...), see documentation._
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,63 @@ Husky improves your commits and more 🐶 *woof!*
 
 # Install
 
+## Easy install (reccomended)
+
+`husky-init` is a one-time command to configure a project with husky.
+
+It installs husky into your project and auto-configures your package.json,
+ensuring that every time you run `yarn|npm install` git is then configured to
+use your hooks (so you don't have to worry about it again).
+
+```shell
+npx husky-init && npm install       # npm
+npx husky-init && yarn              # Yarn 1
+yarn dlx husky-init --yarn2 && yarn # Yarn 2+
+pnpm dlx husky-init && pnpm install # pnpm
 ```
+
+It will:
+* install husky
+* modify `package.json` (adding a
+[`prepare`](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish)
+script)
+* create a sample `pre-commit` hook that you can edit. By default this runs
+  `npm test` when you commit.
+
+## Manual Install
+
+1. Install `husky`
+
+```shell
 npm install husky --save-dev
+yarn add --dev husky
 ```
 
-# Usage
+2. Enable Git hooks
 
-Edit `package.json > prepare` script and run it once:
+```shell
+npx husky install # will configure git to use .husky/ by default
+```
 
-```sh
+3. To automatically have Git hooks enabled after every npm/yarn install, edit
+`package.json` to use one of the [npm/yarm lifecyle
+hooks](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish)
+e.g. `prepare`.
+
+
+```shell
 npm pkg set scripts.prepare="husky install"
-npm run prepare
 ```
 
-Add a hook:
+You should have:
 
-```sh
-npx husky add .husky/pre-commit "npm test"
-git add .husky/pre-commit
-```
-
-Make a commit:
-
-```sh
-git commit -m "Keep calm and commit"
-# `npm test` will run
+```js
+// package.json
+{
+  "scripts": {
+    "prepare": "husky install"
+  }
+}
 ```
 
 # Documentation


### PR DESCRIPTION
Initially, I found it quite hard to understand the husky docs, so I thought I would capture my learning and attempt to make the docs easier to follow. Mainly because I think I will be using husky a lot in the future and I have the memory of a goldfish.

I've clarified:
* husky requires git 2.9+ because of `core.hooksPath` support
* what `prepare` does and why
* what the differences between `husky-init` and `husky install` are
* how to manage hooks code
* grouped and added some more comprehensive examples
* added some notes on how to avoid gotchas (in addition to the troubleshooting section)

I've also conformed the 3 readmes, copying the quick-setup sections from the main docs:
* ./README.md
* ./.github/README.md

Finally, I've also added an example `prepare-commit-msg` hook with an external script, as requested by [jcollum-nutrien](https://github.com/jcollum-nutrien)
