### PR TITLE
feat: add env as a variable to give to husky to set the environment it is run in

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,7 +5,7 @@ import h = require('./')
 // Show usage and exit with code
 function help(code: number) {
   console.log(`Usage:
-  husky install [dir] (default: .husky)
+  husky install [dir] (default: .husky) [env] (default sh)
   husky uninstall
   husky set|add <file> [cmd]`)
   process.exit(code)
@@ -18,12 +18,12 @@ const [x, y] = args
 
 // Set or add command in hook
 const hook = (fn: (a1: string, a2: string) => void) => (): void =>
-  // Show usage if no arguments are provided or more than 2
+  // Show usage if no arguments are provided or more than 3
   !ln || ln > 2 ? help(2) : fn(x, y)
 
 // CLI commands
 const cmds: { [key: string]: () => void } = {
-  install: (): void => (ln > 1 ? help(2) : h.install(x)),
+  install: (): void => (ln > 2 ? help(2) : h.install(x, y)),
   uninstall: h.uninstall,
   set: hook(h.set),
   add: hook(h.add),

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const l = (msg: string): void => console.log(`husky - ${msg}`)
 const git = (args: string[]): cp.SpawnSyncReturns<Buffer> =>
   cp.spawnSync('git', args, { stdio: 'inherit' })
 
-export function install(dir = '.husky'): void {
+export function install(dir: string = '.husky', env: string = 'sh'): void {
   if (process.env.HUSKY === '0') {
     l('HUSKY env variable is set to 0, skipping install')
     return
@@ -42,8 +42,11 @@ export function install(dir = '.husky'): void {
     // Create .husky/_/.gitignore
     fs.writeFileSync(p.join(dir, '_/.gitignore'), '*')
 
+    const install_path = p.join(dir, '_/husky.sh')
     // Copy husky.sh to .husky/_/husky.sh
-    fs.copyFileSync(p.join(__dirname, '../husky.sh'), p.join(dir, '_/husky.sh'))
+    fs.copyFileSync(p.join(__dirname, '../husky.sh'), install_path)
+    // Modify environment to execute in
+    cp.exec(`sed -i 's/sh/${env}/' ${install_path}`)
 
     // Configure repo
     const { error } = git(['config', 'core.hooksPath', dir])


### PR DESCRIPTION
This PR enables users to add as argument to the install script the environment the scripts run in. 
An example of this is to run in `bash` instead of `sh`. 

This PR does not include the scope of optional single args, however so it must be provided as a second argument to the dir.

Example usage `yarn run prepare .husky bash`  or apply directly in the `prepare` section of the `package.json`

This allows us to specify `zsh` as well as other shell environments. 