### PR TITLE
docs: add double-hyphen flag between npx and the command to run

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ To add another hook use `husky add`.
 For example:
 
 ```shell
-npx husky add .husky/commit-msg 'npx --no commitlint --edit "$1"'
+npx husky add .husky/commit-msg 'npx --no -- commitlint --edit "$1"'
 ```
 
 _For Windows users, if you see the help message when running `npx husky add ...`, try `node node_modules/husky/lib/bin add ...` instead. This isn't an issue with husky code._
@@ -485,7 +485,7 @@ Previous `HUSKY_GIT_PARAMS` environment variable is replaced by native params `$
 ```shell
 # .husky/commit-msg (v8)
 # ...
-npx --no commitlint --edit $1
+npx --no -- commitlint --edit $1
 # or
 yarn commitlint --edit $1
 ```


### PR DESCRIPTION
## Description

This PR changes `npx --no` command to `npx --no --` in README

## Related Issue

Close #1157 