### PR TITLE
docs: correct npm pkg set syntax

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,7 @@ npx husky install
 3. To automatically have Git hooks enabled after install, edit `package.json`
 
 ```shell
-npm pkg set scripts.prepare "husky install"
+npm pkg set scripts.prepare="husky install"
 ```
 
 You should have:


### PR DESCRIPTION
From v7 onwards, the `set` instruction needs an equal sign (https://docs.npmjs.com/cli/v7/commands/npm-pkg)
`npm pkg set <field>=<value> [.<subfield>=<value> ...]`