### PR TITLE
docs: Locally installed binaries: use path to binary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -467,6 +467,8 @@ If you were calling directly locally installed binaries, **you need to run them 
 npx --no jest
 # or
 yarn jest
+# or even
+node_modules/.bin/jest
 ```
 
 ## HUSKY_GIT_PARAMS (i.e. commitlint, ...)


### PR DESCRIPTION
Adds another example to https://typicode.github.io/husky/#/?id=locally-installed-binaries

I've benchmarked and it's the fastest way to invoke scripts.

----

Measured with this script:
- [perf-lint-staged.sh.txt](https://github.com/typicode/husky/files/9642758/perf-lint-staged.sh.txt) 386 bytes

From the benchmark, `yarn` is the slowest, and I'm surprised that `npx --no-install` is close to invoking the program directly.

```
➔ ./perf-lint-staged.sh

+ npx --no-install lint-staged (100 iterations)

real	0m26.743s
user	0m22.947s
sys	0m6.517s

+ lint-staged (100 iterations)

real	0m22.514s
user	0m19.717s
sys	0m5.736s

+ yarn lint-staged (100 iterations)

real	0m48.708s
user	0m36.719s
sys	0m9.707s

+ node_modules/.bin/lint-staged (100 iterations)

real	0m20.123s
user	0m17.836s
sys	0m4.876s
```