### PR TITLE
fix: added git not installed error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export function install(dir = '.husky'): void {
   // If git command is not found, status is null and we should return.
   // That's why status value needs to be checked explicitly.
   if (git(['rev-parse']).status !== 0) {
+    l(`git must be installed on your machine`)
     return
   }
 


### PR DESCRIPTION
Added a console log letting the user know that git must be installed on their machine if it is not found during the `husky install`. Addressed issue #1191.