### PR TITLE
fix: handle missing of `_/husky.sh` use-case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export function set(file: string, cmd: string): void {
   fs.writeFileSync(
     file,
     `#!/usr/bin/env sh
+[ -f "$(dirname "$0")/_/husky.sh" ] || husky install || exit 0
 . "$(dirname -- "$0")/_/husky.sh"
 
 ${cmd}


### PR DESCRIPTION
Hello there 👋🏽 

At my company, especially in big repositories, we encountered a lot of cases when a developer's machine has already set his hooks, but the file `_/husky.sh` has moved or not exists. For example when migrating between `husky` versions and the place of `_/husky.sh` changed.

On this PR, the file will check for the existence of `_/husky.sh` and if not exists it will install the file through `husky install`. In case the `husky` package is not installed yet (on the `node_modules`) we set the `|| exist 0`

Another option is to set `npx husky install` instead of `husky install || exit 0`, what do you think? At the moment, at my company, we set the sensitive repositories to work with `husky install || exit 0` and it really reduced the questions of developers stuck while trying to pull from other branches where they got breaking changes in `husky` setup.