### PR TITLE
Adjust instructions for nvm workaround

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -368,9 +368,16 @@ For example, for `nvm` that would be:
 
 ```shell
 # ~/.huskyrc
-# This loads nvm.sh and sets the correct PATH before running hook
+# This loads nvm.sh, sets the correct PATH before running hook, and ensures the project version of Node
 export NVM_DIR="$HOME/.nvm"
+
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# If you have an .nvmrc file, we use the relevant node version
+if [[ -f ".nvmrc" ]]; then
+  nvm use
+fi
+
 ```
 
 ## Hooks not running


### PR DESCRIPTION
I scoured a lot of GitHub issues and Stack Overflow problems. The difficulty in just using:

```sh
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
```

is that - by default - nvm.sh will run the default Node version which isn't necessarily the project's node version. This still won't save anybody manually bouncing between Node versions within different projects, but `.nvmrc` is a very common practice and this should assuage people who run Husky in a project using an `.nvmrc` file that differs from their NVM default.