### PR TITLE
update docs to add message about restarting vs code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -373,7 +373,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 ```
 
-!> **for some apps (eg, VS Code), you can resolve this simply by restarting the app. try this before following any of these steps above!**
+!> **For some apps (e.g., VS Code), you can resolve this simply by restarting the app. Try this before following any of these steps above!**
 
 ## Hooks not running
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -373,6 +373,8 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 ```
 
+!> **for some apps (eg, VS Code), you can resolve this simply by restarting the app. try this before following any of these steps above!**
+
 ## Hooks not running
 
 1. Ensure that you don't have a typo in your filename. For example, `precommit` or `pre-commit.sh` are invalid names. See Git hooks [documentation](https://git-scm.com/docs/githooks) for valid names.


### PR DESCRIPTION
VS Code can get into a weird state where husky `pre-commit`s will fail with `command not found` but the solution is to simply restart VS Code. see https://stackoverflow.com/a/73635509/5504797