### PR TITLE
Make commit hooks created on Windows executable on Linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import cp = require('child_process')
 import fs = require('fs')
 import p = require('path')
+import os = require('os')
 
 // Logger
 const l = (msg: string): void => console.log(`husky - ${msg}`)
@@ -78,6 +79,19 @@ ${cmd}
   )
 
   l(`created ${file}`)
+
+  if (os.type() === 'Windows_NT') {
+    l(
+      `Due to a limitation on Windows systems, the executable bit of the file cannot be set without using git. 
+      To fix this, the file ${file} has been automatically moved to the staging environment and the executable bit has been set using git. 
+      Note that, if you remove the file from the staging environment, the executable bit will be removed. 
+      You can add the file back to the staging environment and include the executable bit using the command 'git update-index -add --chmod=+x ${file}'. 
+      If you have already committed the file, you can add the executable bit using 'git update-index --chmod=+x ${file}'. 
+      You will have to commit the file to have git keep track of the executable bit.`,
+    )
+
+    git(['update-index', '--add', '--chmod=+x', file])
+  }
 }
 
 export function add(file: string, cmd: string): void {


### PR DESCRIPTION
Fixes #1177

Solves the issue of a commit hook not being executable on Linux systems when the commit hook was created on a Windows system.

Previously, when a new commit hook was created on a Windows system, the executable bit (which is required by Git on Linux systems to run a commit hook) was not added to the newly created commit hook file because Windows does not keep track of the executable bit of a file. This resulted in commit hooks not working as intended when the repository was cloned onto a Linux system.

To fix this issue, the executable bit will now be added to the file when creating a new commit hook on a Windows system by using the Git command `git update-index --chmod=+x .\path\to\file`. This solution is a bit of a hack since it requires the user to manually commit the file to actually save the executable bit with the file. However, since Windows does not keep track of the executable bit, it is not possible to fix this issue without performing some sort of git action.