### PR TITLE
fix: docs link

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -9,10 +9,10 @@ assignees: ''
 
 **Troubleshoot**
 - [ ] Before creating an issue, please check:
-https://typicode.github.io/husky/#/?id=troubleshoot
+https://typicode.github.io/husky/troubleshooting.html
 
 If you're migrating from husky 4, see:
-https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v7
+https://typicode.github.io/husky/migrating-from-v4.html
 
 **Context**
 Please describe your issue and provide some context:

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export function install(dir = '.husky'): void {
   }
 
   // Custom dir help
-  const url = 'https://typicode.github.io/husky/#/?id=custom-directory'
+  const url = 'https://typicode.github.io/husky/guide.html#custom-directory'
 
   // Ensure that we're not trying to install outside of cwd
   if (!p.resolve(process.cwd(), dir).startsWith(process.cwd())) {


### PR DESCRIPTION
Fixed broken links in issue template and ``src/index.js``


This PR changes
- https://typicode.github.io/husky/#/?id=troubleshoot
- https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v7
- https://typicode.github.io/husky/#/?id=custom-directory

to

- https://typicode.github.io/husky/troubleshooting.html
- https://typicode.github.io/husky/migrating-from-v4.html
- https://typicode.github.io/husky/guide.html#custom-directory



