### PR TITLE
docs: update hook references in migration guide

### DIFF
--- a/docs/migrating-from-v4.md
+++ b/docs/migrating-from-v4.md
@@ -18,7 +18,7 @@ If you were calling `package.json` scripts using `npm` or `yarn`, **you can simp
 }
 ```
 
-```shell [.husky/commit-msg (v8)]
+```shell [.husky/pre-commit (v8)]
 # ...
 npm test
 npm run foo
@@ -38,7 +38,7 @@ If you were calling locally installed binaries, **you need to run them via your 
 }
 ```
 
-```shell [.husky/commit-msg (v8)]
+```shell [.husky/pre-commit (v8)]
 # ...
 npx --no jest
 # or


### PR DESCRIPTION
The migration guide shows mismatched hooks for the before and after examples, which can be confusing.