### PR TITLE
fix: Do not search for rc file at `/husky/init.sh`

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -14,7 +14,7 @@ if [ -z "$husky_skip_init" ]; then
     exit 0
   fi
 
-  for file in "$XDG_CONFIG_HOME/husky/init.sh" "$HOME/.config/husky/init.sh" "$HOME/.huskyrc.sh"; do
+  for file in "${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh" "$HOME/.huskyrc.sh"; do
     if [ -f "$file" ]; then
       debug "sourcing $file"
       . "$file"


### PR DESCRIPTION
Under most systems, `$XDG_CONFIG_HOME` is not defined. Therefore, in the most common case, Husky would check for the following files in the order:

- `/husky/init.sh`
- `$HOME/.config/husky/init.sh`
- `$HOME/.huskyrc.sh`

Of course, this isn't compliant with the XDG Directory Specification. This fixes the case whwere `XDG_CONFIG_HOME` is not defined - it defaults it to `$HOME/.config`, as per the specification.