### PR TITLE
perf: Use POSIX-defined parameter expansion

### DIFF
--- a/husky.sh
+++ b/husky.sh
@@ -6,7 +6,7 @@ if [ -z "$husky_skip_init" ]; then
     fi
   }
 
-  readonly hook_name="$(basename -- "$0")"
+  readonly hook_name="${0##*/}"
   debug "starting $hook_name..."
 
   if [ "$HUSKY" = "0" ]; then
@@ -25,7 +25,7 @@ if [ -z "$husky_skip_init" ]; then
   readonly husky_skip_init=1
   export husky_skip_init
 
-  if [ "$(basename -- "$SHELL")" = "zsh" ]; then
+  if [ "${SHELL##*/}" = "zsh" ]; then
     zsh --emulate sh -e "$0" "$@"
   else
     sh -e "$0" "$@"


### PR DESCRIPTION
Sometimes, it is difficult to avoid subshells in POSIX sh (making runtime slower), but in this case, [POSIX specifies](https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html) a syntax for parameter expansion that gives us a performance improvement.

This uses the **Remove Largest Prefix Pattern** which has a syntax of  `${parameter##word}`. It modifies the variable _parameter_ by greedily removing a pattern from the start of the string.

In the case of this patch, it simply removes everything up to (and including) the last `/` character. Examples:

- Before: `./pre-commit`
- After: `pre-commit`
- Before: `/usr/bin/zsh`
- After: `zsh` 