### PR TITLE
fix: add scripts field if not present

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -7,7 +7,7 @@ let a = process.argv[2]
 if (a == 'init') {
   let p = process.env.npm_package_json
   let d = JSON.parse(f.readFileSync(p))
-  if (!d.scripts) { d.scripts = {} }
+  d.scripts ||= {}
   d.scripts.prepare = 'husky'
   w('package.json', JSON.stringify(d, null, /\t/.test() ? '\t' : 2))
   process.stdout.write(i())

--- a/bin.js
+++ b/bin.js
@@ -7,6 +7,7 @@ let a = process.argv[2]
 if (a == 'init') {
   let p = process.env.npm_package_json
   let d = JSON.parse(f.readFileSync(p))
+  if (!d.scripts) { d.scripts = {} }
   d.scripts.prepare = 'husky'
   w('package.json', JSON.stringify(d, null, /\t/.test() ? '\t' : 2))
   process.stdout.write(i())


### PR DESCRIPTION
Fixed an error that occurs on installation if the `scripts` field is not present in package.json.

```
$ npx husky init                                                                                                                                                 ~/ghq/github.com/Rhelixa-inc/epiclock-test-report-generator
Need to install the following packages:
husky@9.0.1
Ok to proceed? (y) 
file:///Users/takuya.fukuju/.npm/_npx/0d92fdd791cc1044/node_modules/husky/bin.js:10
  d.scripts.prepare = 'husky'
                    ^

TypeError: Cannot set properties of undefined (setting 'prepare')
    at file:///Users/takuya.fukuju/.npm/_npx/0d92fdd791cc1044/node_modules/husky/bin.js:10:21
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)

Node.js v21.4.0
```