### PR TITLE
fix: insert final newline

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -8,9 +8,9 @@ if (a == 'init') {
   let p = process.env.npm_package_json
   let d = JSON.parse(f.readFileSync(p))
   d.scripts.prepare = 'husky'
-  w('package.json', JSON.stringify(d, null, /\t/.test() ? '\t' : 2))
+  w('package.json', JSON.stringify(d, null, /\t/.test() ? '\t' : 2) + '\n')
   process.stdout.write(i())
-  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test')
+  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test\n')
   process.exit()
 }
 


### PR DESCRIPTION
While it may be controversial, text files are generally preferred to end with a newline.