### PR TITLE
fix: fix init not work on pnpm #1334

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,7 +5,7 @@ import i from './index.js'
 let a = process.argv[2]
 
 if (a == 'init') {
-  let p = process.env.npm_package_json
+  let p = process.env.npm_package_json || './package.json'
   let d = JSON.parse(f.readFileSync(p))
   d.scripts ||= {}
   d.scripts.prepare = 'husky'

--- a/bin.js
+++ b/bin.js
@@ -9,9 +9,9 @@ if (a == 'init') {
   let d = JSON.parse(f.readFileSync(p))
   d.scripts ||= {}
   d.scripts.prepare = 'husky'
-  w(p, JSON.stringify(d, null, /\t/.test() ? '\t' : 2) + '\n')
+  w(p, JSON.stringify(d, null, /\t/.test() ? '\t' : 2))
   process.stdout.write(i())
-  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test\n')
+  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test')
   process.exit()
 }
 

--- a/bin.js
+++ b/bin.js
@@ -5,13 +5,13 @@ import i from './index.js'
 let a = process.argv[2]
 
 if (a == 'init') {
-  let p = process.env.npm_package_json || './package.json'
+  let p = 'package.json'
   let d = JSON.parse(f.readFileSync(p))
   d.scripts ||= {}
   d.scripts.prepare = 'husky'
-  w('package.json', JSON.stringify(d, null, /\t/.test() ? '\t' : 2))
+  w(p, JSON.stringify(d, null, /\t/.test() ? '\t' : 2) + '\n')
   process.stdout.write(i())
-  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test')
+  w('.husky/pre-commit', process.env.npm_config_user_agent.split('/')[0] + ' test\n')
   process.exit()
 }
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -35,6 +35,7 @@ npx husky init
 ```
 
 ```shell [pnpm]
+# On project root.
 pnpm exec husky init
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -35,7 +35,6 @@ npx husky init
 ```
 
 ```shell [pnpm]
-# On project root.
 pnpm exec husky init
 ```
 


### PR DESCRIPTION
`npm_package_json`  env is not supported by pnpm now. (but npm and yarn works)

This is not a perfect fix, the user may not run husky init in project root. in this  case, we need more code that npm and yarn user doest't need, I think this is unfair.  So, we can simple add one line here utill the pnpm support it.

The other way is update doc, let users define a env named `npm_package_json` before `husky init`, but I think that is too complex for users.