### PR TITLE
Clarify Yarn not supporting prepare

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -214,7 +214,7 @@ Run the `husky` command once in your repo. Ideally, include it in the `prepare` 
 ```json [yarn]
 {
   "scripts": {
-    // Yarn doesn't support prepare script
+    // Yarn (v2) doesn't support prepare script
     "postinstall": "husky",
     // Include this if publishing to npmjs.com
     "prepack": "pinst --disable",


### PR DESCRIPTION
It seems only Yarn v2 (and above) don't support `prepare`. Yarn Classic i.e. v1, does.

As such it seems "manual setup if using Yarn" should only be recommended if _not_ using Yarn Classic.

In my testing with Yarn Classic, `yarn husky init` works fine, as does the `prepare` step in `package.json`.