### PR TITLE
Changed default hook script to avoid fail on Windows installations

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -17,7 +17,7 @@ export default (d = '.husky') => {
 	f.mkdirSync(_(), { recursive: true })
 	w(_('.gitignore'), '*')
 	f.copyFileSync(new URL('husky', import.meta.url), _('h'))
-	l.forEach(h => w(_(h), `#!/usr/bin/env sh\nPATH="\${0%/*}"\n. "\${PATH%\\\\*}/h"`, { mode: 0o755 }))
+	l.forEach(h => w(_(h), `#!/usr/bin/env sh\nPATH=\${0%/*}\n. "\${PATH%\\\\*}/h"`, { mode: 0o755 }))
 	w(_('husky.sh'), '')
 	return ''
 }

--- a/index.mjs
+++ b/index.mjs
@@ -17,7 +17,7 @@ export default (d = '.husky') => {
 	f.mkdirSync(_(), { recursive: true })
 	w(_('.gitignore'), '*')
 	f.copyFileSync(new URL('husky', import.meta.url), _('h'))
-	l.forEach(h => w(_(h), `#!/usr/bin/env sh\n. "\${0%/*}/h"`, { mode: 0o755 }))
+	l.forEach(h => w(_(h), `#!/usr/bin/env sh\nPATH="\${0%/*}"\n. "\${PATH%\\\\*}/h"`, { mode: 0o755 }))
 	w(_('husky.sh'), '')
 	return ''
 }

--- a/index.mjs
+++ b/index.mjs
@@ -17,7 +17,7 @@ export default (d = '.husky') => {
 	f.mkdirSync(_(), { recursive: true })
 	w(_('.gitignore'), '*')
 	f.copyFileSync(new URL('husky', import.meta.url), _('h'))
-	l.forEach(h => w(_(h), `#!/usr/bin/env sh\nPATH=\${0%/*}\n. "\${PATH%\\\\*}/h"`, { mode: 0o755 }))
+	l.forEach(h => w(_(h), `#!/usr/bin/env sh\nSUB=\${0%/*}\n. "\${SUB%\\\\*}/h"`, { mode: 0o755 }))
 	w(_('husky.sh'), '')
 	return ''
 }


### PR DESCRIPTION
Recently in Husky v9, an issue came up on Windows installations using Husky (in my case, wsl on Windows), where the default script used by the hooks fails on some Git GUI's (in my case it was GitKraken using a Windows installed Git executable) because the path variable used in the script has a slash in the other direction (`\`). This commit changes this base script to the following:

```
#!/usr/bin/env sh
SUB=${0%/*}
. "${SUB%\\*}/h"
```
instead of:
```
#!/usr/bin/env sh
. "${0%/*}/h"
```

This should work with both types of path separators.

**For me, this change in script fixed all my issues but I'm not sure why this problem is even occurring. I saw that some of the hooks (such as pre-commit) DO use a slash in the other direction (`/`) within GitKraken. Using the hooks via the Git cli on my Windows machine does NOT give problems for the original script.**

_**Note**: Paths that contain both slashes might still have problems as the above script can delete two slashes instead of one (if they are different). To avoid this, an if statement can be added but I'm not sure if this is required due to not knowing how common this situation is._