### PR TITLE
Fix: Prepare scripts condition checks

### DIFF
--- a/bin.mjs
+++ b/bin.mjs
@@ -11,7 +11,7 @@ if (a == 'init') {
 	n = 'package.json'
 	s = f.readFileSync(n)
 	o = JSON.parse(s)
-	;(o.scripts ||= {}).prepare = 'husky'
+	;(o.scripts ||= {}).prepare = '' === (o.scripts ||= {}).prepare ? 'husky' : (o.scripts ||= {}).prepare + ' && husky'
 	w(n, JSON.stringify(o, 0, /\t/.test(s) ? '\t' : 2) + '\n')
 	p.stdout.write(i())
 	try { f.mkdirSync('.husky') } catch {}


### PR DESCRIPTION
## Overview
- This PR will add checks for the prepare scripts if there are commands inside the prepare script it will append the `husky` command or else directly add the husky command.

## Fixes/Covers
- #1387 