### PR TITLE
Get the path from dirname instead of using Bash variable operators

### DIFF
--- a/husky
+++ b/husky
@@ -1,5 +1,12 @@
 #!/usr/bin/env sh
 [ "$HUSKY" = "2" ] && set -x
+if command -v cygpath >/dev/null 2>&1; then
+  u0=$(cygpath -u "$0")
+  if [ "$0" != "$u0" ]; then
+    exec "$u0" "$@"
+  fi
+fi
+
 h="${0##*/}"
 s="${0%/*/*}/$h"
 

--- a/index.mjs
+++ b/index.mjs
@@ -17,7 +17,7 @@ export default (d = '.husky') => {
 	f.mkdirSync(_(), { recursive: true })
 	w(_('.gitignore'), '*')
 	f.copyFileSync(new URL('husky', import.meta.url), _('h'))
-	l.forEach(h => w(_(h), `#!/usr/bin/env sh\n. "\${0%/*}/h"`, { mode: 0o755 }))
+	l.forEach(h => w(_(h), `#!/usr/bin/env sh\n. "\$(dirname "\$0")/h"`, { mode: 0o755 }))
 	w(_('husky.sh'), '')
 	return ''
 }


### PR DESCRIPTION
On Windows, under certain circumstances, the path separator is "\".

This change will ensure compatibility with both Linux and Windows path separators