### PR TITLE
docs: fix some broken (internal) links

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -77,4 +77,4 @@ _This is a basic but working example, check [lint-staged](https://github.com/lin
 
 ### Disabling hooks
 
-Husky doesn't force Git hooks. It can be globally disabled (`HUSKY=0`) or be opt-in if wanted. See the [How To](how-to) section for manual setup and more information.
+Husky doesn't force Git hooks. It can be globally disabled (`HUSKY=0`) or be opt-in if wanted. See the [How To](./how-to) section for manual setup and more information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Husky enhances your commits and more 🐶 _woof!_
 
 Automatically **lint your commit messages**, **code**, and **run tests** upon committing or pushing.
 
-Get started [here](/get-started.md).
+Get started [here](./get-started.md).
 
 ## Features
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -2,7 +2,7 @@
 
 ## Command not found
 
-See [How To](how-to) for solutions.
+See [How To](./how-to) for solutions.
 
 ## Hooks not running
 


### PR DESCRIPTION
This fixes some minor broken links in the docs