### PR TITLE
Fix how-to.html example for CI

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -84,7 +84,7 @@ if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
   process.exit(0)
 }
 const husky = (await import('husky')).default
-console.log(husky())
+console.log(husky.install())
 ```
 
 Then, use it in `prepare`:


### PR DESCRIPTION
In the CI example, the docs incorrectly assume that the default import from the husky package is the install() method, where it is actually an object that has install() as a property. This cost me about 10 minutes just now, so I thought I'd fix the text.