### PR TITLE
docs: added `&` character that needs to get escaped as well

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -69,7 +69,7 @@ For example, here's how you can lint your staged files on each commit with only 
 
 ```shell
 # .husky/pre-commit
-prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's|( |&)|\\ |g') --write --ignore-unknown
 git update-index --again
 ```
 


### PR DESCRIPTION
I've had the problem that not only spaces would need to get escaped, but (probably out of some more) at least `&` character as well as it would lead to unexpected results.