### PR TITLE
Fix issue where example pre-commit file is generated incorrectly

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -15,7 +15,7 @@ if (a == 'init') {
 	w(n, JSON.stringify(o, 0, /\t/.test(s) ? '\t' : 2) + '\n')
 	p.stdout.write(i())
 	try { f.mkdirSync('.husky') } catch {}
-	w('.husky/pre-commit', p.env.npm_config_user_agent?.split('/')[0] ?? 'npm' + ' test\n')
+	w('.husky/pre-commit', (p.env.npm_config_user_agent?.split('/')[0] ?? 'npm') + ' test\n')
 	p.exit()
 }
 


### PR DESCRIPTION
Fix to `bin.js` which incorrectly creates a partial example `pre-commit` file when `npx husky init` is called on systems with npm_config_user_agent set.