### PR TITLE
Subsequent Init runs would clear Husky pre-commit #1520

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -11,11 +11,13 @@ if (a == 'init') {
 	n = 'package.json'
 	s = f.readFileSync(n)
 	o = JSON.parse(s)
-	;(o.scripts ||= {}).prepare = 'husky'
+		; (o.scripts ||= {}).prepare = 'husky'
 	w(n, JSON.stringify(o, 0, /\t/.test(s) ? '\t' : 2) + '\n')
 	p.stdout.write(i())
-	try { f.mkdirSync('.husky') } catch {}
-	w('.husky/pre-commit', (p.env.npm_config_user_agent?.split('/')[0] ?? 'npm') + ' test\n')
+	try {
+		f.mkdirSync('.husky')
+		w('.husky/pre-commit', (p.env.npm_config_user_agent?.split('/')[0] ?? 'npm') + ' test\n', { flag: 'wx' })
+	} catch { }
 	p.exit()
 }
 


### PR DESCRIPTION
Hi,
as stated in #1520 I'm sending You a PR.

In my case, we share the same project between many coleagues. If one would run - erroneously - the "init", would delete the pre-commit hook. This is why - IMHO - would be fine to preserve it.

Regards
FabioG

