### PR TITLE
Add ability to use `init.sh` as a global hook script

### DIFF
--- a/husky
+++ b/husky
@@ -9,7 +9,7 @@ if [ -f "$HOME/.huskyrc" ]; then
 	echo "husky - '~/.huskyrc' is DEPRECATED, please move your code to ~/.config/husky/init.sh"
 fi
 i="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
-[ -f "$i" ] && . "$i"
+[ -f "$i" ] && . "$i" "$n"
 
 [ "${HUSKY-}" = "0" ] && exit 0
 


### PR DESCRIPTION
This is a simple workaround for all the users who have a global set of hooks that get clobbered by changing `core.hooksPath`.  E.g. if I have `core.hooksPath` set globally to run hooks I want run on all repositories, Husky will change that location per-repo.  With this change in place, I can at least create an `init.sh` script to read the hook that is getting executed by Husky, and run my global hook manually first, followed by any Husky hooks.

There may be a different or more robust way the team would like this done, if so feel free to reject this PR or make further suggestions.