### PR TITLE
feat: project scope .husky/init.sh

### DIFF
--- a/docs/es/how-to.md
+++ b/docs/es/how-to.md
@@ -12,6 +12,7 @@ echo "npm test" > .husky/pre-commit
 
 Husky le permite ejecutar comandos locales antes de ejecutar ganchos (hooks). Husky lee comandos de estos archivos:
 
+- `.husky/init.sh`
 - `$XDG_CONFIG_HOME/husky/init.sh`
 - `~/.config/husky/init.sh`
 - `~/.huskyrc` (obsoleto (deprecated))

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -11,6 +11,7 @@ echo "npm test" > .husky/pre-commit
 
 Husky allows you to execute local commands before running hooks. It reads commands from these files:
 
+- `.husky/init.sh`
 - `$XDG_CONFIG_HOME/husky/init.sh`
 - `~/.config/husky/init.sh`
 - `~/.huskyrc` (deprecated)

--- a/docs/ru/how-to.md
+++ b/docs/ru/how-to.md
@@ -11,6 +11,7 @@ echo "npm test" > .husky/pre-commit
 
 Husky позволяет выполнять локальные команды перед запуском хуков. Он считывает команды из следующих файлов:
 
+- `.husky/init.sh`
 - `$XDG_CONFIG_HOME/husky/init.sh`
 - `~/.config/husky/init.sh`
 - `~/.huskyrc` (устарело)

--- a/docs/zh/how-to.md
+++ b/docs/zh/how-to.md
@@ -11,6 +11,7 @@ echo "npm test" > .husky/pre-commit
 
 Husky 允许你在运行钩子之前执行本地命令。它从这些文件中读取命令：
 
+- `.husky/init.sh`
 - `$XDG_CONFIG_HOME/husky/init.sh`
 - `~/.config/husky/init.sh`
 - `~/.huskyrc` (已弃用)

--- a/husky
+++ b/husky
@@ -3,6 +3,9 @@
 n=$(basename "$0")
 s=$(dirname "$(dirname "$0")")/$n
 
+i="${s%/*}/init.sh"
+[ -f "$i" ] && . "$i"
+
 [ ! -f "$s" ] && exit 0
 
 if [ -f "$HOME/.huskyrc" ]; then

--- a/test.sh
+++ b/test.sh
@@ -14,3 +14,4 @@ sh test/9_husky_0.sh
 sh test/10_init.sh
 sh test/11_time.sh
 sh test/12_deprecated.sh
+sh test/13_project_scope_init.sh

--- a/test/13_project_scope_init.sh
+++ b/test/13_project_scope_init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+. test/functions.sh
+setup
+install
+
+npx --no-install husky
+
+git add package.json
+cat >.husky/init.sh <<'EOL'
+#!/usr/bin/env sh
+exit 1
+EOL
+
+expect 1 "git commit -m foo"


### PR DESCRIPTION
I’m working on a monorepo project. Many team members use the same `.git` but do not use or familiar with husky. It’s impractical to expect everyone to set up `~/.config/husky/init.sh` individually.

I’d like to add a commitable project-scope `.husky/init.sh`. 
It runs to execute under `.git/hooks`
