### PR TITLE
fix: add husky label to deprecated warning

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -19,7 +19,7 @@ if (a == 'init') {
 	p.exit()
 }
 
-d = c => console.error(`${c} command is DEPRECATED`)
+d = c => console.error(`husky - ${c} command is DEPRECATED`)
 if (['add', 'set', 'uninstall'].includes(a)) { d(a); p.exit(1) }
 if (a == 'install') d(a)
 


### PR DESCRIPTION
Add husky label to deprecated commands.

Old:
```
install command is DEPRECATED
```

New:
```
husky - install command is DEPRECATED
```

Fixes: https://github.com/typicode/husky/issues/1537