### PR TITLE
fix: improve Node.js version compatibility for scripts setup

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -11,7 +11,8 @@ if (a == 'init') {
 	n = 'package.json'
 	s = f.readFileSync(n)
 	o = JSON.parse(s)
-	;(o.scripts ||= {}).prepare = 'husky'
+	o.scripts = o.scripts || {};
+	o.scripts.prepare = 'husky';
 	w(n, JSON.stringify(o, 0, /\t/.test(s) ? '\t' : 2) + '\n')
 	p.stdout.write(i())
 	try { f.mkdirSync('.husky') } catch {}


### PR DESCRIPTION
## Problem
The current code uses the nullish coalescing assignment operator (`||=`) which is only supported in Node.js 15.0.0 and later versions. This causes syntax errors in projects using older Node.js versions.

## Solution
Replace the `||=` operator with standard JavaScript OR operator pattern that has wider compatibility:
```javascript
o.scripts = o.scripts || {};
o.scripts.prepare = 'husky';
```

## Testing
- None
